### PR TITLE
fix(ingress): deploy keycloak ingress only if ingress and internal keycloak is enabled

### DIFF
--- a/charts/opencloud/templates/keycloak/ingress.yaml
+++ b/charts/opencloud/templates/keycloak/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.keycloak.internal.enabled }}
+{{- if and .Values.ingress.enabled .Values.keycloak.internal.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:


### PR DESCRIPTION
### **User description**
https://github.com/Tim-herbie/opencloud-helm/issues/22


___

### **PR Type**
Bug fix


___

### **Description**
- Restrict Keycloak Ingress creation to when ingress enabled

- Ensure both `.Values.ingress.enabled` and `.Values.keycloak.internal.enabled`


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ingress.yaml</strong><dd><code>Require ingress.enabled in Keycloak ingress template</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/opencloud/templates/keycloak/ingress.yaml

<ul><li>Updated Helm template <code>if</code> condition<br> <li> Added <code>.Values.ingress.enabled</code> check alongside <br><code>.Values.keycloak.internal.enabled</code></ul>


</details>


  </td>
  <td><a href="https://github.com/Tim-herbie/opencloud-helm/pull/24/files#diff-07f7b0bfd0f7a7d9a53ff19f57e4f7ebc809d14a5cc7bb06022844ff43b3dc08">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

