### PR TITLE
feat: add proxy configuration file to Helm chart

### DIFF
--- a/charts/opencloud/files/opencloud/proxy.yaml.gotmpl
+++ b/charts/opencloud/files/opencloud/proxy.yaml.gotmpl
@@ -1,0 +1,41 @@
+# Source: https://raw.githubusercontent.com/opencloud-eu/opencloud-compose/refs/heads/main/config/opencloud/proxy.yaml
+# This adds four additional routes to the proxy. Forwarding
+# request on '/carddav/', '/caldav/' and the respective '/.well-knwown'
+# endpoints to the radicale container and setting the required headers.
+additional_policies:
+  - name: default
+    routes:
+      - endpoint: /caldav/
+        backend: http://radicale:5232
+        remote_user_header: X-Remote-User
+        skip_x_access_token: true
+        additional_headers:
+          - X-Script-Name: /caldav
+      - endpoint: /.well-known/caldav
+        backend: http://radicale:5232
+        remote_user_header: X-Remote-User
+        skip_x_access_token: true
+        additional_headers:
+          - X-Script-Name: /caldav
+      - endpoint: /carddav/
+        backend: http://radicale:5232
+        remote_user_header: X-Remote-User
+        skip_x_access_token: true
+        additional_headers:
+          - X-Script-Name: /carddav
+      - endpoint: /.well-known/carddav
+        backend: http://radicale:5232
+        remote_user_header: X-Remote-User
+        skip_x_access_token: true
+        additional_headers:
+          - X-Script-Name: /carddav
+# To enable the radicale web UI add this rule.
+# "unprotected" is True because the Web UI itself ask for
+# the password.
+# Also set "type" to "internal" in the config/radicale/config
+#      - endpoint: /caldav/.web/
+#        backend: http://radicale:5232/
+#        unprotected: true
+#        skip_x_access_token: true
+#        additional_headers:
+#          - X-Script-Name: /caldav

--- a/charts/opencloud/templates/opencloud/configmap.yaml
+++ b/charts/opencloud/templates/opencloud/configmap.yaml
@@ -23,6 +23,14 @@ data:
 {{ .Values.opencloud.config.csp | nindent 4 }}
 {{- end }}
 
+  # Proxy configuration
+  proxy.yaml: |-
+{{- if empty .Values.opencloud.config.proxy -}}
+{{ tpl (.Files.Get "files/opencloud/proxy.yaml.gotmpl") . | nindent 4 }}
+{{- else -}}
+{{ .Values.opencloud.config.proxy | nindent 4 }}
+{{- end }}
+
   # Banned password list
   banned-password-list.txt: |-
 {{- if empty .Values.opencloud.config.bannedPasswordList -}}

--- a/charts/opencloud/templates/opencloud/deployment.yaml
+++ b/charts/opencloud/templates/opencloud/deployment.yaml
@@ -386,6 +386,9 @@ spec:
               mountPath: /etc/opencloud/csp.yaml
               subPath: csp.yaml
             - name: config-files
+              mountPath: /etc/opencloud/proxy.yaml
+              subPath: proxy.yaml
+            - name: config-files
               mountPath: /etc/opencloud/banned-password-list.txt
               subPath: banned-password-list.txt
             {{- if and (.Values.opencloud.nats.external.enabled) (not .Values.opencloud.nats.external.tls.certTrusted) }}
@@ -433,9 +436,6 @@ spec:
         - name: config-files
           configMap:
             name: {{ include "opencloud.opencloud.fullname" . }}-config
-        - name: proxy-config
-          configMap:
-            name: {{ include "opencloud.opencloud.fullname" . }}-proxy-config
         {{ if and (.Values.opencloud.nats.external.enabled) (not .Values.opencloud.nats.external.tls.certTrusted) }}
         - name: nats-ca
           secret:

--- a/charts/opencloud/values.yaml
+++ b/charts/opencloud/values.yaml
@@ -489,6 +489,25 @@ opencloud:
     appRegistry: {}
     # CSP configuration
     csp: {}
+    # Proxy configuration
+    # ==== Example ====
+    # role_quotas: # Sets default Quota's for roles (in bytes)
+    #   'd7beeea8-8ff4-406b-8fb6-ab2dd81e6b11': 15000000000 # User
+    #   '2aadd357-682c-406b-8874-293091995fdd': 15000000000 # SpaceAdmin
+    #   '71881883-1768-46bd-a24d-a356a2afdf7f': 15000000000 # Admin
+    # 
+    # role_assignment:
+    #   driver: oidc
+    #   oidc_role_mapper:
+    #     role_claim: groups
+    #     role_mapping:
+    #       - role_name: admin                # OpenCloud Role
+    #         claim_value: "authentik Admins" # Authentik Group
+    #       - role_name: spaceadmin
+    #         claim_value: "opencloud-spaces"
+    #       - role_name: user
+    #         claim_value: "opencloud"
+    proxy: {}
     # Banned password list configuration
     # Format: Multi-line string (not YAML array)
     # Use the |- syntax to preserve line breaks


### PR DESCRIPTION
This PR adds the missing `proxy.yaml` file to the chart. This file can be used to specify role mappings between an Identity Provider (e.g., Authentik) and OpenCloud roles, such as Admin, User, or SpaceAdmin (see [Automatic Role Assignments](https://docs.opencloud.eu/docs/next/admin/configuration/authentication-and-user-management/external-idp#automatic-role-assignments)). Additionally, it makes it possible to add default quotas to roles. See [Default User Quota](https://docs.opencloud.eu/docs/next/admin/configuration/default-user-quota).

Credits: > This implementation is based on and closely mirrors the work originally done by XA21X in [this commit](https://github.com/XA21X/opencloud-helm/commit/3fedb5a9e27de8ced2f45e749b9e168a697ff218).