### PR TITLE
add affinity to opencloud deployment

### DIFF
--- a/charts/opencloud/templates/opencloud/deployment.yaml
+++ b/charts/opencloud/templates/opencloud/deployment.yaml
@@ -448,4 +448,8 @@ spec:
           configMap:
             name: {{ include "opencloud.opencloud.fullname" . }}-web-extensions-init
         {{- end }}
+      {{- with .Values.opencloud.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/opencloud/values.yaml
+++ b/charts/opencloud/values.yaml
@@ -654,6 +654,7 @@ opencloud:
         storageClass: ""
         # Access mode (ReadWriteOnce or ReadWriteMany for multiple replicas)
         accessMode: ReadWriteMany
+  # affinity: {}
 
 # =====================================================================
 # GATEWAY-API HTTPRoute


### PR DESCRIPTION
Simply add the option to set affinity for the OpenCloud deployment. Useful if you have a mixed topology or want to set anti-affinity for multi-pod deployments.