### PR TITLE
chore(release): v3.0.0

### DIFF
--- a/.github/release-pr-body.md
+++ b/.github/release-pr-body.md
@@ -1,0 +1,23 @@
+## Release 3.0.0
+
+Base: changes since 2.2.0.
+
+OpenCloud version from values.yaml: 6.1.0
+
+### Pull Requests
+- [#73](https://github.com/Tim-herbie/opencloud-helm/pull/73) chore(release): v3.0.0
+
+### Changelog
+## [3.0.0] - 2026-04-23
+
+### Breaking Changes
+- [#73](https://github.com/Tim-herbie/opencloud-helm/pull/73) chore(release): v3.0.0
+
+### Features
+- None
+
+### Fixes
+- None
+
+### Chore / Docs / CI / Other
+- None

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+<!-- release-bot:start -->
+
+## [3.0.0] - 2026-04-23
+
+### Breaking Changes
+- [#73](https://github.com/Tim-herbie/opencloud-helm/pull/73) chore(release): v3.0.0
+
+### Features
+- None
+
+### Fixes
+- None
+
+### Chore / Docs / CI / Other
+- None
+
+<!-- release-bot:end -->

--- a/CHANGELOG_SECTION.md
+++ b/CHANGELOG_SECTION.md
@@ -1,0 +1,13 @@
+## [3.0.0] - 2026-04-23
+
+### Breaking Changes
+- [#73](https://github.com/Tim-herbie/opencloud-helm/pull/73) chore(release): v3.0.0
+
+### Features
+- None
+
+### Fixes
+- None
+
+### Chore / Docs / CI / Other
+- None

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ OpenCloud is a cloud collaboration platform that provides file sync and share, d
 
 | OpenCloud Version | Helm Chart Version |
 |-------------------|--------|
+| 6.1.0            | 3.0.0 |
 | 4.1.0            | 0.2.4, 0.3.0 |
 | 5.0.0            | 0.4.0 |
 | 5.0.1            | 1.0.0 |
@@ -78,7 +79,7 @@ Follow these steps to quickly deploy OpenCloud using the Helm chart:
   ```sh
   helm install opencloud \
     oci://ghcr.io/tim-herbie/opencloud-helm/opencloud \
-    --version 2.2.0 \
+    --version 3.0.0 \
     --namespace opencloud \
     --create-namespace
   ```

--- a/charts/opencloud/Chart.yaml
+++ b/charts/opencloud/Chart.yaml
@@ -9,9 +9,9 @@ maintainers:
   - name: Tim Herbert
     url: https://timherbert.de
 type: application
-version: 2.2.0
+version: 3.0.0
 # renovate: datasource=docker depName=opencloudeu/opencloud-rolling
-appVersion: latest
+appVersion: 6.1.0
 kubeVersion: ""
 sources:
   - https://github.com/Tim-herbie/opencloud-helm


### PR DESCRIPTION
## Release 3.0.0

Base: changes since 2.2.0.

OpenCloud version from values.yaml: 6.1.0

### Pull Requests
- [#73](https://github.com/Tim-herbie/opencloud-helm/pull/73) chore(release): v3.0.0

### Changelog
## [3.0.0] - 2026-04-23

### Breaking Changes
- [#73](https://github.com/Tim-herbie/opencloud-helm/pull/73) chore(release): v3.0.0

### Features
- None

### Fixes
- None

### Chore / Docs / CI / Other
- None
