### PR TITLE
chore(release): v2.2.1

### DIFF
--- a/.github/release-pr-body.md
+++ b/.github/release-pr-body.md
@@ -1,0 +1,23 @@
+## Release 2.2.1
+
+Base: changes since 2.2.0.
+
+OpenCloud version from values.yaml: 6.1.0
+
+### Pull Requests
+- [#77](https://github.com/Tim-herbie/opencloud-helm/pull/77) Add release bot
+
+### Changelog
+## [2.2.1] - 2026-04-23
+
+### Breaking Changes
+- None
+
+### Features
+- None
+
+### Fixes
+- None
+
+### Chore / Docs / CI / Other
+- [#77](https://github.com/Tim-herbie/opencloud-helm/pull/77) Add release bot

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+<!-- release-bot:start -->
+
+## [2.2.1] - 2026-04-23
+
+### Breaking Changes
+- None
+
+### Features
+- None
+
+### Fixes
+- None
+
+### Chore / Docs / CI / Other
+- [#77](https://github.com/Tim-herbie/opencloud-helm/pull/77) Add release bot
+
+<!-- release-bot:end -->

--- a/CHANGELOG_SECTION.md
+++ b/CHANGELOG_SECTION.md
@@ -1,0 +1,13 @@
+## [2.2.1] - 2026-04-23
+
+### Breaking Changes
+- None
+
+### Features
+- None
+
+### Fixes
+- None
+
+### Chore / Docs / CI / Other
+- [#77](https://github.com/Tim-herbie/opencloud-helm/pull/77) Add release bot

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ OpenCloud is a cloud collaboration platform that provides file sync and share, d
 | 5.1.0            | 2.0.0 |
 | 5.2.0            | 2.0.1 |
 | 6.0.0            | 2.1.0 |
-| 6.1.0            | 2.2.0 |
+| 6.1.0            | 2.2.0, 2.2.1 |
 
 
 ## 💡 Contributing
@@ -78,7 +78,7 @@ Follow these steps to quickly deploy OpenCloud using the Helm chart:
   ```sh
   helm install opencloud \
     oci://ghcr.io/tim-herbie/opencloud-helm/opencloud \
-    --version 2.2.0 \
+    --version 2.2.1 \
     --namespace opencloud \
     --create-namespace
   ```

--- a/charts/opencloud/Chart.yaml
+++ b/charts/opencloud/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
   - name: Tim Herbert
     url: https://timherbert.de
 type: application
-version: 2.2.0
+version: 2.2.1
 # renovate: datasource=docker depName=opencloudeu/opencloud-rolling
 appVersion: latest
 kubeVersion: ""


### PR DESCRIPTION
## Release 2.2.1

Base: changes since 2.2.0.

OpenCloud version from values.yaml: 6.1.0

### Pull Requests
- [#77](https://github.com/Tim-herbie/opencloud-helm/pull/77) Add release bot

### Changelog
## [2.2.1] - 2026-04-23

### Breaking Changes
- None

### Features
- None

### Fixes
- None

### Chore / Docs / CI / Other
- [#77](https://github.com/Tim-herbie/opencloud-helm/pull/77) Add release bot
