### PR TITLE
chore(release): v2.3.0

### DIFF
--- a/.github/release-pr-body.md
+++ b/.github/release-pr-body.md
@@ -1,0 +1,30 @@
+## Release 2.3.0
+
+Base: changes since 2.2.0.
+
+OpenCloud version from values.yaml: 6.2.0
+
+### Pull Requests
+- [#84](https://github.com/Tim-herbie/opencloud-helm/pull/84) chore(deps): update docker.io/opencloudeu/opencloud-rolling docker tag to v6.2.0
+- [#79](https://github.com/Tim-herbie/opencloud-helm/pull/79) chore(deps): update peter-evans/create-pull-request action to v8
+- [#83](https://github.com/Tim-herbie/opencloud-helm/pull/83) feat: Add helm-unittest pipeline test cases for web extensions, ingress, and gateway HTTPRoutes
+- [#80](https://github.com/Tim-herbie/opencloud-helm/pull/80) Add new web extensions: arcade, calculator, cast, maps, pastebin
+- [#77](https://github.com/Tim-herbie/opencloud-helm/pull/77) Add release bot
+
+### Changelog
+## [2.3.0] - 2026-05-12
+
+### Breaking Changes
+- None
+
+### Features
+- [#83](https://github.com/Tim-herbie/opencloud-helm/pull/83) feat: Add helm-unittest pipeline test cases for web extensions, ingress, and gateway HTTPRoutes
+- [#80](https://github.com/Tim-herbie/opencloud-helm/pull/80) Add new web extensions: arcade, calculator, cast, maps, pastebin
+
+### Fixes
+- None
+
+### Chore / Docs / CI / Other
+- [#84](https://github.com/Tim-herbie/opencloud-helm/pull/84) chore(deps): update docker.io/opencloudeu/opencloud-rolling docker tag to v6.2.0
+- [#79](https://github.com/Tim-herbie/opencloud-helm/pull/79) chore(deps): update peter-evans/create-pull-request action to v8
+- [#77](https://github.com/Tim-herbie/opencloud-helm/pull/77) Add release bot

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+<!-- release-bot:start -->
+
+## [2.3.0] - 2026-05-12
+
+### Breaking Changes
+- None
+
+### Features
+- [#83](https://github.com/Tim-herbie/opencloud-helm/pull/83) feat: Add helm-unittest pipeline test cases for web extensions, ingress, and gateway HTTPRoutes
+- [#80](https://github.com/Tim-herbie/opencloud-helm/pull/80) Add new web extensions: arcade, calculator, cast, maps, pastebin
+
+### Fixes
+- None
+
+### Chore / Docs / CI / Other
+- [#84](https://github.com/Tim-herbie/opencloud-helm/pull/84) chore(deps): update docker.io/opencloudeu/opencloud-rolling docker tag to v6.2.0
+- [#79](https://github.com/Tim-herbie/opencloud-helm/pull/79) chore(deps): update peter-evans/create-pull-request action to v8
+- [#77](https://github.com/Tim-herbie/opencloud-helm/pull/77) Add release bot
+
+<!-- release-bot:end -->

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ OpenCloud is a cloud collaboration platform that provides file sync and share, d
 | 5.2.0            | 2.0.1 |
 | 6.0.0            | 2.1.0 |
 | 6.1.0            | 2.2.0 |
+| 6.2.0            | 2.3.0 |
 
 
 ## 💡 Contributing
@@ -78,7 +79,7 @@ Follow these steps to quickly deploy OpenCloud using the Helm chart:
   ```sh
   helm install opencloud \
     oci://ghcr.io/tim-herbie/opencloud-helm/opencloud \
-    --version 2.2.0 \
+    --version 2.3.0 \
     --namespace opencloud \
     --create-namespace
   ```

--- a/charts/opencloud/Chart.yaml
+++ b/charts/opencloud/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
   - name: Tim Herbert
     url: https://timherbert.de
 type: application
-version: 2.2.0
+version: 2.3.0
 # renovate: datasource=docker depName=opencloudeu/opencloud-rolling
 appVersion: latest
 kubeVersion: ""


### PR DESCRIPTION
## Release 2.3.0

Base: changes since 2.2.0.

OpenCloud version from values.yaml: 6.2.0

### Pull Requests
- [#84](https://github.com/Tim-herbie/opencloud-helm/pull/84) chore(deps): update docker.io/opencloudeu/opencloud-rolling docker tag to v6.2.0
- [#79](https://github.com/Tim-herbie/opencloud-helm/pull/79) chore(deps): update peter-evans/create-pull-request action to v8
- [#83](https://github.com/Tim-herbie/opencloud-helm/pull/83) feat: Add helm-unittest pipeline test cases for web extensions, ingress, and gateway HTTPRoutes
- [#80](https://github.com/Tim-herbie/opencloud-helm/pull/80) Add new web extensions: arcade, calculator, cast, maps, pastebin
- [#77](https://github.com/Tim-herbie/opencloud-helm/pull/77) Add release bot

### Changelog
## [2.3.0] - 2026-05-12

### Breaking Changes
- None

### Features
- [#83](https://github.com/Tim-herbie/opencloud-helm/pull/83) feat: Add helm-unittest pipeline test cases for web extensions, ingress, and gateway HTTPRoutes
- [#80](https://github.com/Tim-herbie/opencloud-helm/pull/80) Add new web extensions: arcade, calculator, cast, maps, pastebin

### Fixes
- None

### Chore / Docs / CI / Other
- [#84](https://github.com/Tim-herbie/opencloud-helm/pull/84) chore(deps): update docker.io/opencloudeu/opencloud-rolling docker tag to v6.2.0
- [#79](https://github.com/Tim-herbie/opencloud-helm/pull/79) chore(deps): update peter-evans/create-pull-request action to v8
- [#77](https://github.com/Tim-herbie/opencloud-helm/pull/77) Add release bot
