### PR TITLE
chore(release): v2.4.2

### DIFF
--- a/.github/release-pr-body.md
+++ b/.github/release-pr-body.md
@@ -1,14 +1,16 @@
-## Release 2.4.1
+## Release 2.4.2
 
-Base: changes since 2.4.0.
+Base: changes since 2.4.1.
 
 OpenCloud version from values.yaml: 7.0.0
 
 ### Pull Requests
-- [#93](https://github.com/Tim-herbie/opencloud-helm/pull/93) fix: idm authentication #92
+- [#98](https://github.com/Tim-herbie/opencloud-helm/pull/98) Make credential migration hook configurable via `opencloud.migration.enabled`
+- [#95](https://github.com/Tim-herbie/opencloud-helm/pull/95) chore(deps): update docker.io/library/busybox docker tag to v1.38
+- [#96](https://github.com/Tim-herbie/opencloud-helm/pull/96) chore(deps): update docker.io/apache/tika docker tag to v3.3.1.0
 
 ### Changelog
-## [2.4.1] - 2026-05-22
+## [2.4.2] - 2026-05-31
 
 ### Breaking Changes
 - None
@@ -17,7 +19,9 @@ OpenCloud version from values.yaml: 7.0.0
 - None
 
 ### Fixes
-- [#93](https://github.com/Tim-herbie/opencloud-helm/pull/93) fix: idm authentication #92
+- None
 
 ### Chore / Docs / CI / Other
-- None
+- [#95](https://github.com/Tim-herbie/opencloud-helm/pull/95) chore(deps): update docker.io/library/busybox docker tag to v1.38
+- [#96](https://github.com/Tim-herbie/opencloud-helm/pull/96) chore(deps): update docker.io/apache/tika docker tag to v3.3.1.0
+- [#98](https://github.com/Tim-herbie/opencloud-helm/pull/98) Make credential migration hook configurable via `opencloud.migration.enabled`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 <!-- release-bot:start -->
 
+## [2.4.2] - 2026-05-31
+
+### Breaking Changes
+- None
+
+### Features
+- None
+
+### Fixes
+- None
+
+### Chore / Docs / CI / Other
+- [#95](https://github.com/Tim-herbie/opencloud-helm/pull/95) chore(deps): update docker.io/library/busybox docker tag to v1.38
+- [#96](https://github.com/Tim-herbie/opencloud-helm/pull/96) chore(deps): update docker.io/apache/tika docker tag to v3.3.1.0
+- [#98](https://github.com/Tim-herbie/opencloud-helm/pull/98) Make credential migration hook configurable via `opencloud.migration.enabled`
+
+
 ## [2.4.1] - 2026-05-22
 
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ OpenCloud is a cloud collaboration platform that provides file sync and share, d
 | 6.0.0            | 2.1.0 |
 | 6.1.0            | 2.2.0 |
 | 6.2.0            | 2.3.0 |
-| 7.0.0            | 2.4.0, 2.4.1 |
+| 7.0.0            | 2.4.0, 2.4.1, 2.4.2 |
 
 
 ## 💡 Contributing
@@ -80,7 +80,7 @@ Follow these steps to quickly deploy OpenCloud using the Helm chart:
   ```sh
   helm install opencloud \
     oci://ghcr.io/tim-herbie/opencloud-helm/opencloud \
-    --version 2.4.1 \
+    --version 2.4.2 \
     --namespace opencloud \
     --create-namespace
   ```

--- a/charts/opencloud/Chart.yaml
+++ b/charts/opencloud/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
   - name: Tim Herbert
     url: https://timherbert.de
 type: application
-version: 2.4.1
+version: 2.4.2
 # renovate: datasource=docker depName=opencloudeu/opencloud-rolling
 appVersion: latest
 kubeVersion: ""


### PR DESCRIPTION
## Release 2.4.2

Base: changes since 2.4.1.

OpenCloud version from values.yaml: 7.0.0

### Pull Requests
- [#98](https://github.com/Tim-herbie/opencloud-helm/pull/98) Make credential migration hook configurable via `opencloud.migration.enabled`
- [#95](https://github.com/Tim-herbie/opencloud-helm/pull/95) chore(deps): update docker.io/library/busybox docker tag to v1.38
- [#96](https://github.com/Tim-herbie/opencloud-helm/pull/96) chore(deps): update docker.io/apache/tika docker tag to v3.3.1.0

### Changelog
## [2.4.2] - 2026-05-31

### Breaking Changes
- None

### Features
- None

### Fixes
- None

### Chore / Docs / CI / Other
- [#95](https://github.com/Tim-herbie/opencloud-helm/pull/95) chore(deps): update docker.io/library/busybox docker tag to v1.38
- [#96](https://github.com/Tim-herbie/opencloud-helm/pull/96) chore(deps): update docker.io/apache/tika docker tag to v3.3.1.0
- [#98](https://github.com/Tim-herbie/opencloud-helm/pull/98) Make credential migration hook configurable via `opencloud.migration.enabled`
