### PR TITLE
chore(release): v2.4.5

### DIFF
--- a/.github/release-pr-body.md
+++ b/.github/release-pr-body.md
@@ -1,17 +1,16 @@
-## Release 2.4.4
+## Release 2.4.5
 
-Base: changes since 2.4.3.
+Base: changes since 2.4.4.
 
-OpenCloud version from values.yaml: 7.2.0
+OpenCloud version from values.yaml: 7.3.0
 
 ### Pull Requests
-- [#108](https://github.com/Tim-herbie/opencloud-helm/pull/108) chore(deps): update actions/checkout action to v7
-- [#104](https://github.com/Tim-herbie/opencloud-helm/pull/104) chore(deps): update docker.io/collabora/code docker tag to v26
-- [#105](https://github.com/Tim-herbie/opencloud-helm/pull/105) chore(deps): update quay.io/keycloak/keycloak docker tag to v26.6.3
-- [#109](https://github.com/Tim-herbie/opencloud-helm/pull/109) chore(deps): update docker.io/opencloudeu/opencloud-rolling docker tag to v7.2.0
+- [#114](https://github.com/Tim-herbie/opencloud-helm/pull/114) chore(deps): update docker.io/opencloudeu/opencloud-rolling docker tag to v7.3.0
+- [#111](https://github.com/Tim-herbie/opencloud-helm/pull/111) chore(deps): update quay.io/keycloak/keycloak docker tag to v26.7.0
+- [#112](https://github.com/Tim-herbie/opencloud-helm/pull/112) chore(deps): update docker.io/collabora/code docker tag to v26.04.2.1.1
 
 ### Changelog
-## [2.4.4] - 2026-06-25
+## [2.4.5] - 2026-07-14
 
 ### Breaking Changes
 - None
@@ -23,7 +22,6 @@ OpenCloud version from values.yaml: 7.2.0
 - None
 
 ### Chore / Docs / CI / Other
-- [#108](https://github.com/Tim-herbie/opencloud-helm/pull/108) chore(deps): update actions/checkout action to v7
-- [#104](https://github.com/Tim-herbie/opencloud-helm/pull/104) chore(deps): update docker.io/collabora/code docker tag to v26
-- [#105](https://github.com/Tim-herbie/opencloud-helm/pull/105) chore(deps): update quay.io/keycloak/keycloak docker tag to v26.6.3
-- [#109](https://github.com/Tim-herbie/opencloud-helm/pull/109) chore(deps): update docker.io/opencloudeu/opencloud-rolling docker tag to v7.2.0
+- [#114](https://github.com/Tim-herbie/opencloud-helm/pull/114) chore(deps): update docker.io/opencloudeu/opencloud-rolling docker tag to v7.3.0
+- [#111](https://github.com/Tim-herbie/opencloud-helm/pull/111) chore(deps): update quay.io/keycloak/keycloak docker tag to v26.7.0
+- [#112](https://github.com/Tim-herbie/opencloud-helm/pull/112) chore(deps): update docker.io/collabora/code docker tag to v26.04.2.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 <!-- release-bot:start -->
 
+## [2.4.5] - 2026-07-14
+
+### Breaking Changes
+- None
+
+### Features
+- None
+
+### Fixes
+- None
+
+### Chore / Docs / CI / Other
+- [#114](https://github.com/Tim-herbie/opencloud-helm/pull/114) chore(deps): update docker.io/opencloudeu/opencloud-rolling docker tag to v7.3.0
+- [#111](https://github.com/Tim-herbie/opencloud-helm/pull/111) chore(deps): update quay.io/keycloak/keycloak docker tag to v26.7.0
+- [#112](https://github.com/Tim-herbie/opencloud-helm/pull/112) chore(deps): update docker.io/collabora/code docker tag to v26.04.2.1.1
+
+
 ## [2.4.4] - 2026-06-25
 
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ OpenCloud is a cloud collaboration platform that provides file sync and share, d
 | 7.0.0            | 2.4.0, 2.4.1, 2.4.2 |
 | 7.1.0            | 2.4.3 |
 | 7.2.0            | 2.4.4 |
+| 7.3.0            | 2.4.5 |
 
 
 ## 💡 Contributing
@@ -82,7 +83,7 @@ Follow these steps to quickly deploy OpenCloud using the Helm chart:
   ```sh
   helm install opencloud \
     oci://ghcr.io/tim-herbie/opencloud-helm/opencloud \
-    --version 2.4.4 \
+    --version 2.4.5 \
     --namespace opencloud \
     --create-namespace
   ```

--- a/charts/opencloud/Chart.yaml
+++ b/charts/opencloud/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
   - name: Tim Herbert
     url: https://timherbert.de
 type: application
-version: 2.4.4
+version: 2.4.5
 # renovate: datasource=docker depName=opencloudeu/opencloud-rolling
 appVersion: latest
 kubeVersion: ""


### PR DESCRIPTION
## Release 2.4.5

Base: changes since 2.4.4.

OpenCloud version from values.yaml: 7.3.0

### Pull Requests
- [#114](https://github.com/Tim-herbie/opencloud-helm/pull/114) chore(deps): update docker.io/opencloudeu/opencloud-rolling docker tag to v7.3.0
- [#111](https://github.com/Tim-herbie/opencloud-helm/pull/111) chore(deps): update quay.io/keycloak/keycloak docker tag to v26.7.0
- [#112](https://github.com/Tim-herbie/opencloud-helm/pull/112) chore(deps): update docker.io/collabora/code docker tag to v26.04.2.1.1

### Changelog
## [2.4.5] - 2026-07-14

### Breaking Changes
- None

### Features
- None

### Fixes
- None

### Chore / Docs / CI / Other
- [#114](https://github.com/Tim-herbie/opencloud-helm/pull/114) chore(deps): update docker.io/opencloudeu/opencloud-rolling docker tag to v7.3.0
- [#111](https://github.com/Tim-herbie/opencloud-helm/pull/111) chore(deps): update quay.io/keycloak/keycloak docker tag to v26.7.0
- [#112](https://github.com/Tim-herbie/opencloud-helm/pull/112) chore(deps): update docker.io/collabora/code docker tag to v26.04.2.1.1
