### PR TITLE
chore(release): v2.4.6

### DIFF
--- a/.github/release-pr-body.md
+++ b/.github/release-pr-body.md
@@ -5,6 +5,7 @@ Base: changes since 2.4.5.
 OpenCloud version from values.yaml: 7.3.0
 
 ### Pull Requests
+- [#118](https://github.com/Tim-herbie/opencloud-helm/pull/118) chore(release): v2.4.6
 - [#117](https://github.com/Tim-herbie/opencloud-helm/pull/117) fix: collaboration nats connection to opencloud
 
 ### Changelog
@@ -20,4 +21,4 @@ OpenCloud version from values.yaml: 7.3.0
 - [#117](https://github.com/Tim-herbie/opencloud-helm/pull/117) fix: collaboration nats connection to opencloud
 
 ### Chore / Docs / CI / Other
-- None
+- [#118](https://github.com/Tim-herbie/opencloud-helm/pull/118) chore(release): v2.4.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,21 @@ All notable changes to this project will be documented in this file.
 - [#117](https://github.com/Tim-herbie/opencloud-helm/pull/117) fix: collaboration nats connection to opencloud
 
 ### Chore / Docs / CI / Other
+- [#118](https://github.com/Tim-herbie/opencloud-helm/pull/118) chore(release): v2.4.6
+
+
+## [2.4.6] - 2026-07-17
+
+### Breaking Changes
+- None
+
+### Features
+- None
+
+### Fixes
+- [#117](https://github.com/Tim-herbie/opencloud-helm/pull/117) fix: collaboration nats connection to opencloud
+
+### Chore / Docs / CI / Other
 - None
 
 


### PR DESCRIPTION
## Release 2.4.6

Base: changes since 2.4.5.

OpenCloud version from values.yaml: 7.3.0

### Pull Requests
- [#118](https://github.com/Tim-herbie/opencloud-helm/pull/118) chore(release): v2.4.6
- [#117](https://github.com/Tim-herbie/opencloud-helm/pull/117) fix: collaboration nats connection to opencloud

### Changelog
## [2.4.6] - 2026-07-17

### Breaking Changes
- None

### Features
- None

### Fixes
- [#117](https://github.com/Tim-herbie/opencloud-helm/pull/117) fix: collaboration nats connection to opencloud

### Chore / Docs / CI / Other
- [#118](https://github.com/Tim-herbie/opencloud-helm/pull/118) chore(release): v2.4.6
