### PR TITLE
chore: move set OC_ADMIN_USER_ID always instead only when oidc is ena…

### DIFF
--- a/charts/opencloud/templates/opencloud/deployment.yaml
+++ b/charts/opencloud/templates/opencloud/deployment.yaml
@@ -276,8 +276,6 @@ spec:
               value: {{ .Values.opencloud.proxyUserOidcClaim | quote }}
             - name: PROXY_USER_CS3_CLAIM
               value: {{ .Values.opencloud.proxyUserCs3Claim | quote }}
-            - name: OC_ADMIN_USER_ID
-              value: {{ .Values.opencloud.adminUserId | quote }}
             - name: GRAPH_ASSIGN_DEFAULT_USER_ROLE
               value: {{ .Values.opencloud.graphAssignDefaultUserRole | quote }}
             - name: GRAPH_USERNAME_MATCH
@@ -404,6 +402,11 @@ spec:
                 secretKeyRef:
                   name: {{ $initSecretName }}
                   key: idmServicePassword
+            - name: OC_ADMIN_USER_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $initSecretName }}
+                  key: adminUserID
             - name: IDM_ADMIN_PASSWORD
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
It´s not possible to use the integrated IDM/IDP at the moment because the ENV `OC_ADMIN_USER_ID` will only set if oidc is enabled.

Therefore it´s necessary to set the ENV always.