### PR TITLE
chore(release): v2.4.7

### DIFF
--- a/.github/release-pr-body.md
+++ b/.github/release-pr-body.md
@@ -1,14 +1,26 @@
-## Release 2.4.6
+## Release 2.4.7
 
-Base: changes since 2.4.5.
+Base: changes since 2.4.6.
 
-OpenCloud version from values.yaml: 7.3.0
+OpenCloud version from values.yaml: 7.4.0
 
 ### Pull Requests
-- [#117](https://github.com/Tim-herbie/opencloud-helm/pull/117) fix: collaboration nats connection to opencloud
+- [#136](https://github.com/Tim-herbie/opencloud-helm/pull/136) chore(deps): update docker.io/collabora/code docker tag to v26.04.2.4.1
+- [#139](https://github.com/Tim-herbie/opencloud-helm/pull/139) chore(deps): update docker.io/opencloudeu/opencloud-rolling docker tag to v7.4.0
+- [#140](https://github.com/Tim-herbie/opencloud-helm/pull/140) chore(deps): update quay.io/keycloak/keycloak docker tag to v26.7.1
+- [#135](https://github.com/Tim-herbie/opencloud-helm/pull/135) chore(deps): update opencloudeu/web-extensions docker tag
+- [#134](https://github.com/Tim-herbie/opencloud-helm/pull/134) chore(deps): update dependency node to v24
+- [#133](https://github.com/Tim-herbie/opencloud-helm/pull/133) chore(deps): update opencloudeu/web-extensions docker tag
+- [#132](https://github.com/Tim-herbie/opencloud-helm/pull/132) Enable Renovate updates for web extension image tags
+- [#131](https://github.com/Tim-herbie/opencloud-helm/pull/131) chore(deps): update actions/upload-artifact action to v7
+- [#130](https://github.com/Tim-herbie/opencloud-helm/pull/130) chore(deps): update actions/setup-node action to v7
+- [#128](https://github.com/Tim-herbie/opencloud-helm/pull/128) chore(tests): add e2e tests
+- [#129](https://github.com/Tim-herbie/opencloud-helm/pull/129) fix: improve httproute and gateway usability
+- [#126](https://github.com/Tim-herbie/opencloud-helm/pull/126) chore(docs): add minimal-setup docs example
+- [#124](https://github.com/Tim-herbie/opencloud-helm/pull/124) chore: move set OC_ADMIN_USER_ID always instead only when oidc is ena…
 
 ### Changelog
-## [2.4.6] - 2026-07-17
+## [2.4.7] - 2026-08-09
 
 ### Breaking Changes
 - None
@@ -17,7 +29,18 @@ OpenCloud version from values.yaml: 7.3.0
 - None
 
 ### Fixes
-- [#117](https://github.com/Tim-herbie/opencloud-helm/pull/117) fix: collaboration nats connection to opencloud
+- [#129](https://github.com/Tim-herbie/opencloud-helm/pull/129) fix: improve httproute and gateway usability
 
 ### Chore / Docs / CI / Other
-- None
+- [#136](https://github.com/Tim-herbie/opencloud-helm/pull/136) chore(deps): update docker.io/collabora/code docker tag to v26.04.2.4.1
+- [#139](https://github.com/Tim-herbie/opencloud-helm/pull/139) chore(deps): update docker.io/opencloudeu/opencloud-rolling docker tag to v7.4.0
+- [#140](https://github.com/Tim-herbie/opencloud-helm/pull/140) chore(deps): update quay.io/keycloak/keycloak docker tag to v26.7.1
+- [#135](https://github.com/Tim-herbie/opencloud-helm/pull/135) chore(deps): update opencloudeu/web-extensions docker tag
+- [#134](https://github.com/Tim-herbie/opencloud-helm/pull/134) chore(deps): update dependency node to v24
+- [#133](https://github.com/Tim-herbie/opencloud-helm/pull/133) chore(deps): update opencloudeu/web-extensions docker tag
+- [#131](https://github.com/Tim-herbie/opencloud-helm/pull/131) chore(deps): update actions/upload-artifact action to v7
+- [#130](https://github.com/Tim-herbie/opencloud-helm/pull/130) chore(deps): update actions/setup-node action to v7
+- [#128](https://github.com/Tim-herbie/opencloud-helm/pull/128) chore(tests): add e2e tests
+- [#126](https://github.com/Tim-herbie/opencloud-helm/pull/126) chore(docs): add minimal-setup docs example
+- [#124](https://github.com/Tim-herbie/opencloud-helm/pull/124) chore: move set OC_ADMIN_USER_ID always instead only when oidc is ena…
+- [#132](https://github.com/Tim-herbie/opencloud-helm/pull/132) Enable Renovate updates for web extension image tags

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to this project will be documented in this file.
 
 <!-- release-bot:start -->
 
+## [2.4.7] - 2026-08-09
+
+### Breaking Changes
+- None
+
+### Features
+- None
+
+### Fixes
+- [#129](https://github.com/Tim-herbie/opencloud-helm/pull/129) fix: improve httproute and gateway usability
+
+### Chore / Docs / CI / Other
+- [#136](https://github.com/Tim-herbie/opencloud-helm/pull/136) chore(deps): update docker.io/collabora/code docker tag to v26.04.2.4.1
+- [#139](https://github.com/Tim-herbie/opencloud-helm/pull/139) chore(deps): update docker.io/opencloudeu/opencloud-rolling docker tag to v7.4.0
+- [#140](https://github.com/Tim-herbie/opencloud-helm/pull/140) chore(deps): update quay.io/keycloak/keycloak docker tag to v26.7.1
+- [#135](https://github.com/Tim-herbie/opencloud-helm/pull/135) chore(deps): update opencloudeu/web-extensions docker tag
+- [#134](https://github.com/Tim-herbie/opencloud-helm/pull/134) chore(deps): update dependency node to v24
+- [#133](https://github.com/Tim-herbie/opencloud-helm/pull/133) chore(deps): update opencloudeu/web-extensions docker tag
+- [#131](https://github.com/Tim-herbie/opencloud-helm/pull/131) chore(deps): update actions/upload-artifact action to v7
+- [#130](https://github.com/Tim-herbie/opencloud-helm/pull/130) chore(deps): update actions/setup-node action to v7
+- [#128](https://github.com/Tim-herbie/opencloud-helm/pull/128) chore(tests): add e2e tests
+- [#126](https://github.com/Tim-herbie/opencloud-helm/pull/126) chore(docs): add minimal-setup docs example
+- [#124](https://github.com/Tim-herbie/opencloud-helm/pull/124) chore: move set OC_ADMIN_USER_ID always instead only when oidc is ena…
+- [#132](https://github.com/Tim-herbie/opencloud-helm/pull/132) Enable Renovate updates for web extension image tags
+
+
 ## [2.4.6] - 2026-07-17
 
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ OpenCloud is a cloud collaboration platform that provides file sync and share, d
 | 7.1.0            | 2.4.3 |
 | 7.2.0            | 2.4.4 |
 | 7.3.0            | 2.4.5, 2.4.6 |
+| 7.4.0            | 2.4.7 |
 
 
 ## 💡 Contributing
@@ -83,7 +84,7 @@ Follow these steps to quickly deploy OpenCloud using the Helm chart:
   ```sh
   helm install opencloud \
     oci://ghcr.io/tim-herbie/opencloud-helm/opencloud \
-    --version 2.4.6 \
+    --version 2.4.7 \
     --namespace opencloud \
     --create-namespace
   ```

--- a/charts/opencloud/Chart.yaml
+++ b/charts/opencloud/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
   - name: Tim Herbert
     url: https://timherbert.de
 type: application
-version: 2.4.6
+version: 2.4.7
 # renovate: datasource=docker depName=opencloudeu/opencloud-rolling
 appVersion: latest
 kubeVersion: ""


### PR DESCRIPTION
## Release 2.4.7

Base: changes since 2.4.6.

OpenCloud version from values.yaml: 7.4.0

### Pull Requests
- [#136](https://github.com/Tim-herbie/opencloud-helm/pull/136) chore(deps): update docker.io/collabora/code docker tag to v26.04.2.4.1
- [#139](https://github.com/Tim-herbie/opencloud-helm/pull/139) chore(deps): update docker.io/opencloudeu/opencloud-rolling docker tag to v7.4.0
- [#140](https://github.com/Tim-herbie/opencloud-helm/pull/140) chore(deps): update quay.io/keycloak/keycloak docker tag to v26.7.1
- [#135](https://github.com/Tim-herbie/opencloud-helm/pull/135) chore(deps): update opencloudeu/web-extensions docker tag
- [#134](https://github.com/Tim-herbie/opencloud-helm/pull/134) chore(deps): update dependency node to v24
- [#133](https://github.com/Tim-herbie/opencloud-helm/pull/133) chore(deps): update opencloudeu/web-extensions docker tag
- [#132](https://github.com/Tim-herbie/opencloud-helm/pull/132) Enable Renovate updates for web extension image tags
- [#131](https://github.com/Tim-herbie/opencloud-helm/pull/131) chore(deps): update actions/upload-artifact action to v7
- [#130](https://github.com/Tim-herbie/opencloud-helm/pull/130) chore(deps): update actions/setup-node action to v7
- [#128](https://github.com/Tim-herbie/opencloud-helm/pull/128) chore(tests): add e2e tests
- [#129](https://github.com/Tim-herbie/opencloud-helm/pull/129) fix: improve httproute and gateway usability
- [#126](https://github.com/Tim-herbie/opencloud-helm/pull/126) chore(docs): add minimal-setup docs example
- [#124](https://github.com/Tim-herbie/opencloud-helm/pull/124) chore: move set OC_ADMIN_USER_ID always instead only when oidc is ena…

### Changelog
## [2.4.7] - 2026-08-09

### Breaking Changes
- None

### Features
- None

### Fixes
- [#129](https://github.com/Tim-herbie/opencloud-helm/pull/129) fix: improve httproute and gateway usability

### Chore / Docs / CI / Other
- [#136](https://github.com/Tim-herbie/opencloud-helm/pull/136) chore(deps): update docker.io/collabora/code docker tag to v26.04.2.4.1
- [#139](https://github.com/Tim-herbie/opencloud-helm/pull/139) chore(deps): update docker.io/opencloudeu/opencloud-rolling docker tag to v7.4.0
- [#140](https://github.com/Tim-herbie/opencloud-helm/pull/140) chore(deps): update quay.io/keycloak/keycloak docker tag to v26.7.1
- [#135](https://github.com/Tim-herbie/opencloud-helm/pull/135) chore(deps): update opencloudeu/web-extensions docker tag
- [#134](https://github.com/Tim-herbie/opencloud-helm/pull/134) chore(deps): update dependency node to v24
- [#133](https://github.com/Tim-herbie/opencloud-helm/pull/133) chore(deps): update opencloudeu/web-extensions docker tag
- [#131](https://github.com/Tim-herbie/opencloud-helm/pull/131) chore(deps): update actions/upload-artifact action to v7
- [#130](https://github.com/Tim-herbie/opencloud-helm/pull/130) chore(deps): update actions/setup-node action to v7
- [#128](https://github.com/Tim-herbie/opencloud-helm/pull/128) chore(tests): add e2e tests
- [#126](https://github.com/Tim-herbie/opencloud-helm/pull/126) chore(docs): add minimal-setup docs example
- [#124](https://github.com/Tim-herbie/opencloud-helm/pull/124) chore: move set OC_ADMIN_USER_ID always instead only when oidc is ena…
- [#132](https://github.com/Tim-herbie/opencloud-helm/pull/132) Enable Renovate updates for web extension image tags
