### PR TITLE
fix(csp): allow external OIDC domain in frame-src and script-src

### DIFF
--- a/charts/opencloud/files/opencloud/csp.yaml.gotmpl
+++ b/charts/opencloud/files/opencloud/csp.yaml.gotmpl
@@ -1,6 +1,7 @@
 directives:
   child-src:
     - '''self'''
+
   connect-src:
     - '''self'''
     - 'blob:'
@@ -8,40 +9,59 @@ directives:
     - 'wss://{{ .Values.global.domain.companion }}/'
     - 'https://raw.githubusercontent.com/opencloud-eu/awesome-apps/'
     - 'https://update.opencloud.eu/'
-    - 'https://{{ .Values.global.domain.oidc  }}/'
+    # Required when using an external OIDC provider
+    - 'https://{{ .Values.global.domain.oidc }}/'
+
   default-src:
     - '''none'''
+
   font-src:
     - '''self'''
+
   frame-ancestors:
     - '''self'''
+
   frame-src:
     - '''self'''
     - 'blob:'
     - 'https://embed.diagrams.net/'
-    # In contrary to bash and docker the default is given after the | character
+    # Collabora Online
     - 'https://{{ .Values.global.domain.collabora }}/'
-    # This is needed for the external-sites web extension when embedding sites
+    # Required for the external-sites web extension
     - 'https://docs.opencloud.eu'
+    # Required for OIDC silent token renewal (hidden iframe).
+    # Without this entry browsers block the silent renew flow when an
+    # external Identity Provider is used.
+    - 'https://{{ .Values.global.domain.oidc }}/'
+
   img-src:
     - '''self'''
     - 'data:'
     - 'blob:'
     - 'https://raw.githubusercontent.com/opencloud-eu/awesome-apps/'
-    # In contrary to bash and docker the default is given after the | character
+    # Collabora Online
     - 'https://{{ .Values.global.domain.collabora }}/'
+
   manifest-src:
     - '''self'''
+
   media-src:
     - '''self'''
+
   object-src:
     - '''self'''
     - 'blob:'
+
   script-src:
     - '''self'''
     - '''unsafe-inline'''
+    # Required when using an external OIDC provider
+    - 'https://{{ .Values.global.domain.oidc }}/'
+
   style-src:
     - '''self'''
     - '''unsafe-inline'''
+
   worker-src:
     - '''self'''
+    - 'blob:'


### PR DESCRIPTION
## Summary

Update the default CSP template so that the configured OIDC / Identity Provider domain is allowed in `frame-src` and `script-src`.

This is required for silent token renewal when using an external OIDC provider.

## Problem

When OpenCloud is configured with an external Identity Provider (e.g. Authentik, Keycloak, etc.), the web client uses a hidden iframe for silent token renewal (`oidc-client-ts`).

The previous CSP template already included the OIDC domain in `connect-src`, but **not** in `frame-src`. As a result browsers blocked the iframe with an error similar to:
```
index.html-T5teOsLD.mjs:6 RuntimeError: cannot load external application importer as applicationPath is not a valid module federation remote entry
    at zp (index.html-T5teOsLD.mjs:6:45513)
    at index.html-T5teOsLD.mjs:6:58402
    at Array.map (<anonymous>)
    at gm (index.html-T5teOsLD.mjs:6:58395)
    at Object.bootstrapApp (index.html-T5teOsLD.mjs:6:75950)
(anonymous) @ index.html-T5teOsLD.mjs:6
oidc-client-ts-BEYfVK5L.mjs:1 Framing 'https://auth.example.net/' violates the following Content Security Policy directive: "frame-src 'self' blob: https://embed.diagrams.net/ https://office.example.net/ https://docs.opencloud.eu". The request has been blocked.
```