### PR TITLE
fix: preserve proxy policies with role quotas

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -281,7 +281,7 @@ jobs:
 
       # Debug if helm install fails
       - name: Debug pods if failed
-        if: steps.pods_wait.outcome == 'failure'
+        if: ${{ failure() }}
         run: |
           echo "==== Pods ===="
           kubectl get pods -A
@@ -315,21 +315,24 @@ jobs:
 
       # Debug if helm install fails
       - name: Debug opencloud pod if failed
-        if: steps.e2e_tests.outcome == 'failure'
+        if: ${{ failure() }}
         run: |
-          kubectl -n opencloud-test logs deploy/opencloud-test-opencloud
+          kubectl -n opencloud-test logs deploy/opencloud-test-opencloud --all-containers=true || true
+          kubectl -n opencloud-test logs deploy/opencloud-test-opencloud --all-containers=true --previous || true
+          kubectl -n opencloud-test describe pod -l app.kubernetes.io/component=opencloud || true
+          kubectl -n opencloud-test get events --sort-by=.lastTimestamp || true
 
       # Debug if helm install fails
       - name: Debug collabora pod if failed
-        if: steps.e2e_tests.outcome == 'failure'
+        if: ${{ failure() }}
         run: |
-          kubectl -n opencloud-test logs deploy/opencloud-test-collabora
+          kubectl -n opencloud-test logs deploy/opencloud-test-collabora --all-containers=true || true
 
       # Debug if helm install fails
       - name: Debug collaboration pod if failed
-        if: steps.e2e_tests.outcome == 'failure'
+        if: ${{ failure() }}
         run: |
-          kubectl -n opencloud-test logs deploy/opencloud-test-collaboration
+          kubectl -n opencloud-test logs deploy/opencloud-test-collaboration --all-containers=true || true
 
       - name: Upload Playwright report
         if: always()

--- a/charts/opencloud/README.md
+++ b/charts/opencloud/README.md
@@ -329,6 +329,7 @@ This will prepend `my-registry.com/` to all image references in the chart. For e
 | `opencloud.proxyRoleAssignmentOidcClaim` | OIDC claim for role assignment | `roles` |
 | `opencloud.proxyOidcAccessTokenVerifyMethod` | OIDC access token verify method | `jwt` |
 | `opencloud.oidc.scope` | OIDC scope for web | `openid profile email groups roles` |
+| `opencloud.config.proxyRoleQuotas` | Role UUID to storage quota in bytes; merged into the proxy configuration without replacing built-in proxy policies | `{}` |
 | `opencloud.nats.internalEndpoint` | Internal NATS endpoint | `127.0.0.1:9233` |
 | `opencloud.nats.host` | NATS host | `0.0.0.0` |
 | `opencloud.nats.port` | NATS port | `9233` |

--- a/charts/opencloud/README.md
+++ b/charts/opencloud/README.md
@@ -330,6 +330,8 @@ This will prepend `my-registry.com/` to all image references in the chart. For e
 | `opencloud.proxyOidcAccessTokenVerifyMethod` | OIDC access token verify method | `jwt` |
 | `opencloud.oidc.scope` | OIDC scope for web | `openid profile email groups roles` |
 | `opencloud.config.proxyRoleQuotas` | Role UUID to storage quota in bytes; merged into the proxy configuration without replacing built-in proxy policies | `{}` |
+| `opencloud.policies.enabled` | Mount configured OPA Rego policies into OpenCloud | `false` |
+| `opencloud.policies.policies` | OPA Rego policy files mounted at `/etc/opencloud/policies` | `[]` |
 | `opencloud.nats.internalEndpoint` | Internal NATS endpoint | `127.0.0.1:9233` |
 | `opencloud.nats.host` | NATS host | `0.0.0.0` |
 | `opencloud.nats.port` | NATS port | `9233` |

--- a/charts/opencloud/README.md
+++ b/charts/opencloud/README.md
@@ -287,6 +287,7 @@ This will prepend `my-registry.com/` to all image references in the chart. For e
 | `opencloud.existingSecret` | Name of the existing secret | `` |
 | `opencloud.adminPassword` | Admin password | `admin` |
 | `opencloud.createDemoUsers` | Create demo users (default `true` for integrated IDM) | `true` |
+| `opencloud.asyncUploads` | Keep upload sessions available during postprocessing | `true` |
 | `opencloud.excludeServices` | Services to exclude from starting (set `["idp"]` when using external OIDC). The external LDAP env vars (`OC_LDAP_*`, `GRAPH_LDAP_*`, `FRONTEND_LDAP_SERVER_WRITE_ENABLED`) and the external LDAP bind secret (`opencloud.ldap.secretRef`, default `<release-name>-opencloud-ldap`, chart-generated from `opencloud.ldap.adminPassword`) are only used when `idp` is excluded; with the built-in IDP running they are omitted and the bind passwords come from the generated init secret. | `[]` |
 | `opencloud.theme.urls.imprint` | Imprint URL shown in the web UI footer (empty = hidden) | `https://opencloud.eu/en/legal-notice` |
 | `opencloud.theme.urls.privacy` | Privacy policy URL shown in the web UI footer (empty = hidden) | `https://opencloud.eu/en/data-protection-notice` |

--- a/charts/opencloud/deployments/flux/clamav/clamav.yaml
+++ b/charts/opencloud/deployments/flux/clamav/clamav.yaml
@@ -3,6 +3,38 @@ kind: Namespace
 metadata:
   name: clamav
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: flux
+  namespace: clamav
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: flux-reconciler
+  namespace: clamav
+rules:
+  # Namespace-scoped namespace-admin for Helm reconciliation. This cannot
+  # create or modify cluster-scoped resources such as Namespaces or CRDs.
+  - apiGroups: ["*"]
+    resources: ["*"]
+    verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: flux-reconciler
+  namespace: clamav
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: flux-reconciler
+subjects:
+  - kind: ServiceAccount
+    name: flux
+    namespace: clamav
+---
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
@@ -20,6 +52,7 @@ metadata:
 spec:
   interval: 15m
   timeout: 5m
+  serviceAccountName: flux
   chart:
     spec:
       chart: clamav

--- a/charts/opencloud/deployments/flux/opencloud/namespace.yaml
+++ b/charts/opencloud/deployments/flux/opencloud/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: opencloud

--- a/charts/opencloud/deployments/flux/opencloud/opencloud.yaml
+++ b/charts/opencloud/deployments/flux/opencloud/opencloud.yaml
@@ -8,10 +8,68 @@
 #   1. `cp opencloud.yaml opencloud-oc2.yaml`
 #   2. Edit metadata.name, releaseName, global.domain.opencloud
 #   3. Apply it.
+---
 apiVersion: v1
-kind: Namespace
+kind: ServiceAccount
 metadata:
-  name: opencloud
+  name: flux
+  namespace: opencloud
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: flux-reconciler
+  namespace: opencloud
+rules:
+  # Namespace-scoped namespace-admin for Helm reconciliation. This cannot
+  # create or modify cluster-scoped resources such as Namespaces or CRDs.
+  - apiGroups: ["*"]
+    resources: ["*"]
+    verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: flux-reconciler
+  namespace: opencloud
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: flux-reconciler
+subjects:
+  - kind: ServiceAccount
+    name: flux
+    namespace: opencloud
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: opencloud-flux-referencegrant
+  namespace: kube-system
+rules:
+  # The shared Cilium Gateway is in kube-system. Helm must adopt and manage
+  # only OpenCloud's cross-namespace ReferenceGrant there.
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["referencegrants"]
+    verbs: ["create"]
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["referencegrants"]
+    resourceNames: ["opencloud-reference-grant"]
+    verbs: ["get", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: opencloud-flux-referencegrant
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: opencloud-flux-referencegrant
+subjects:
+  - kind: ServiceAccount
+    name: flux
+    namespace: opencloud
 ---
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository
@@ -52,6 +110,7 @@ metadata:
 spec:
   interval: 15m
   timeout: 5m
+  serviceAccountName: flux
   chart:
     spec:
       chart: ./charts/opencloud

--- a/charts/opencloud/deployments/flux/opencloud/opencloud.yaml
+++ b/charts/opencloud/deployments/flux/opencloud/opencloud.yaml
@@ -41,36 +41,6 @@ subjects:
     name: flux
     namespace: opencloud
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: opencloud-flux-referencegrant
-  namespace: kube-system
-rules:
-  # The shared Cilium Gateway is in kube-system. Helm must adopt and manage
-  # only OpenCloud's cross-namespace ReferenceGrant there.
-  - apiGroups: ["gateway.networking.k8s.io"]
-    resources: ["referencegrants"]
-    verbs: ["create"]
-  - apiGroups: ["gateway.networking.k8s.io"]
-    resources: ["referencegrants"]
-    resourceNames: ["opencloud-reference-grant"]
-    verbs: ["get", "update", "patch", "delete"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: opencloud-flux-referencegrant
-  namespace: kube-system
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: opencloud-flux-referencegrant
-subjects:
-  - kind: ServiceAccount
-    name: flux
-    namespace: opencloud
----
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository
 metadata:

--- a/charts/opencloud/deployments/flux/opencloud/opencloud.yaml
+++ b/charts/opencloud/deployments/flux/opencloud/opencloud.yaml
@@ -99,6 +99,8 @@ spec:
         enabled: true
     opencloud:
       logLevel: info
+      # Production: require trusted certificates for OpenCloud connections.
+      insecure: false
       migration:
         enabled: false
       # Using external Keycloak OIDC + external OpenLDAP: the bundled IDM/idp
@@ -122,7 +124,8 @@ spec:
       ldap:
         secretRef: ldap-bind-secrets
         uri: ldaps://openldap.openldap.svc.cluster.local:636
-        insecure: true
+        # Production: require a trusted LDAP certificate.
+        insecure: false
         bindDN: cn=admin,dc=opencloud,dc=eu
         user:
           baseDN: ou=users,dc=opencloud,dc=eu

--- a/charts/opencloud/deployments/flux/opencloud/opencloud.yaml
+++ b/charts/opencloud/deployments/flux/opencloud/opencloud.yaml
@@ -99,8 +99,8 @@ spec:
         enabled: true
     opencloud:
       logLevel: info
-      # Production: require trusted certificates for OpenCloud connections.
-      insecure: false
+      # Development uses self-signed certificates. Set false in production.
+      insecure: true
       migration:
         enabled: false
       # Using external Keycloak OIDC + external OpenLDAP: the bundled IDM/idp
@@ -124,8 +124,8 @@ spec:
       ldap:
         secretRef: ldap-bind-secrets
         uri: ldaps://openldap.openldap.svc.cluster.local:636
-        # Production: require a trusted LDAP certificate.
-        insecure: false
+        # Development uses a self-signed LDAP certificate. Set false in production.
+        insecure: true
         bindDN: cn=admin,dc=opencloud,dc=eu
         user:
           baseDN: ou=users,dc=opencloud,dc=eu

--- a/charts/opencloud/deployments/flux/opencloud/opencloud.yaml
+++ b/charts/opencloud/deployments/flux/opencloud/opencloud.yaml
@@ -121,6 +121,10 @@ spec:
           accessDeniedHelp: ""
       ldap:
         secretRef: ldap-bind-secrets
+      config:
+        proxyRoleQuotas:
+          'd7beeea8-8ff4-406b-8fb6-ab2dd81e6b11': 0
+          '2aadd357-682c-406b-8874-293091995fdd': 0
       storage:
         # Default: decomposed (PVC-backed metadata + blobs, no S3). Switch to "s3"
         # (external S3) or "posixfs" below to use the alternatives.
@@ -160,7 +164,6 @@ spec:
     features:
       externalUserManagement:
         enabled: true
-        adminUUID: "0ab77e6d-23b4-4ba3-9843-a3b3efdcfc53"
         autoprovisionAccounts:
           enabled: true
           claimUserName: sub
@@ -264,8 +267,6 @@ spec:
     insecure:
       oidcIdpInsecure: true
       ocHttpApiInsecure: true
-    secretRefs:
-      ldapSecretRef: ldap-bind-secrets
     ingress:
       enabled: false
       ingressClassName: nginx
@@ -279,10 +280,6 @@ spec:
         namespace: kube-system
         port: 443
         sectionName: opencloud
-    quotas:
-      roles:
-        'd7beeea8-8ff4-406b-8fb6-ab2dd81e6b11': 0
-        '2aadd357-682c-406b-8874-293091995fdd': 0
     replicas: 1
 ---
 # ---------------------------------------------------------------------------
@@ -371,6 +368,10 @@ spec:
 #         scope: "openid profile email groups"
 #       ldap:
 #         secretRef: ldap-bind-secrets
+#       config:
+#         proxyRoleQuotas:
+#           'd7beeea8-8ff4-406b-8fb6-ab2dd81e6b11': 0
+#           '2aadd357-682c-406b-8874-293091995fdd': 0
 #       storage:
 #         # Default: decomposed (PVC-backed metadata + blobs, no S3). Switch to "s3"
 #         # (external S3) or "posixfs" below to use the alternatives.
@@ -410,7 +411,6 @@ spec:
 #     features:
 #       externalUserManagement:
 #         enabled: true
-#         adminUUID: "0ab77e6d-23b4-4ba3-9843-a3b3efdcfc53"
 #         autoprovisionAccounts:
 #           enabled: true
 #           claimUserName: sub
@@ -514,8 +514,6 @@ spec:
 #     insecure:
 #       oidcIdpInsecure: true
 #       ocHttpApiInsecure: true
-#     secretRefs:
-#       ldapSecretRef: ldap-bind-secrets
 #     ingress:
 #       enabled: false
 #       ingressClassName: nginx
@@ -529,8 +527,4 @@ spec:
 #         namespace: kube-system
 #         port: 443
 #         sectionName: opencloud2
-#     quotas:
-#       roles:
-#         'd7beeea8-8ff4-406b-8fb6-ab2dd81e6b11': 0
-#         '2aadd357-682c-406b-8874-293091995fdd': 0
 #     replicas: 1

--- a/charts/opencloud/deployments/flux/opencloud/opencloud.yaml
+++ b/charts/opencloud/deployments/flux/opencloud/opencloud.yaml
@@ -470,12 +470,6 @@ spec:
 #               insecure: true
 #               disableProof: false
 #               iconURI: https://collabora2.opencloud.test/favicon.ico
-#             - name: OnlyOffice
-#               product: OnlyOffice
-#               enabled: false
-#               uri: "https://onlyoffice.opencloud.test"
-#               insecure: true
-#               disableProof: false
 #     insecure:
 #       oidcIdpInsecure: true
 #       ocHttpApiInsecure: true

--- a/charts/opencloud/deployments/flux/opencloud/opencloud.yaml
+++ b/charts/opencloud/deployments/flux/opencloud/opencloud.yaml
@@ -121,86 +121,41 @@ spec:
           accessDeniedHelp: ""
       ldap:
         secretRef: ldap-bind-secrets
+        uri: ldaps://openldap.openldap.svc.cluster.local:636
+        insecure: true
+        bindDN: cn=admin,dc=opencloud,dc=eu
+        user:
+          baseDN: ou=users,dc=opencloud,dc=eu
+          schema:
+            id: openCloudUUID
+        group:
+          baseDN: ou=groups,dc=opencloud,dc=eu
+          createBaseDN: ou=custom,ou=groups,dc=opencloud,dc=eu
+          schema:
+            id: openCloudUUID
+      ldapServerWriteEnabled: true
+      proxyAutoprovisionAccounts: true
+      proxyAutoprovisionClaimUsername: sub
+      proxyRoleAssignmentDriver: oidc
+      proxyRoleAssignmentOidcClaim: roles
       config:
         proxyRoleQuotas:
           'd7beeea8-8ff4-406b-8fb6-ab2dd81e6b11': 0
           '2aadd357-682c-406b-8874-293091995fdd': 0
-      storage:
-        # Default: decomposed (PVC-backed metadata + blobs, no S3). Switch to "s3"
-        # (external S3) or "posixfs" below to use the alternatives.
-        mode: decomposed
-        # usersDriver: posix       # auto-derived from mode=posixfs; uncomment to override
-        # systemDriver: decomposed # only "decomposed"/"decomposeds3" valid; system has no posix option
-        # posixfs:
-        #   persistence:
-        #     enabled: true
-        #     size: 60Gi
-        #     accessMode: ReadWriteOnce
-        #     # accessMode: ReadWriteMany  # RWX (e.g. CephFS / NFS >=4.2) allows RollingUpdate + multi-replica; fs must support flock + xattrs
-        # --- Decomposed alternative (uncomment to switch) ---
-        decomposed:
-          persistence:
-            enabled: true
-            size: 60Gi
-            # accessMode: ReadWriteOnce  # RWO: only one pod can mount at a time; the chart auto-switches the Deployment strategy to Recreate
-            accessMode: ReadWriteMany  # RWX (e.g. CephFS) allows RollingUpdate + multi-replica
-        # --- External S3 alternative (uncomment to switch) ---
-        # Requires a pre-created Secret with keys `accessKey` and `secretKey`.
-        # Reference it via `storage.s3.external.existingSecret` (below) and
-        # `secretRefs.s3CredentialsSecretRef` (top-level) so OpenCloud can read it.
-        # s3:
-        #   enabled: true
-        #   external:
-        #     endpoint: https://s3.example.com       # your S3 / Ceph / external MinIO endpoint
-        #     region: default
-        #     existingSecret: s3secret                # Secret with accessKey/secretKey keys
-        #     bucket: opencloud-bucket
-        #     createBucket: true
-    # secretRefs:
-    #   s3CredentialsSecretRef: s3secret  # only needed when storage.mode = s3
-    oidc:
-      issuerUrl: https://keycloak.opencloud.test/realms/openCloud
-      clientId: web
-    features:
-      externalUserManagement:
+      antivirus:
         enabled: true
-        autoprovisionAccounts:
-          enabled: true
-          claimUserName: sub
-        oidc:
-          domain: keycloak.opencloud.test
-          issuerURI: https://keycloak.opencloud.test/realms/openCloud
-          userIDClaim: sub
-          userIDClaimAttributeMapping: username
-          roleAssignment:
-            claim: roles
-        ldap:
-          writeable: true
-          uri: ldaps://openldap.openldap.svc.cluster.local:636
-          insecure: true
-          bindDN: cn=admin,dc=opencloud,dc=eu
-          user:
-            userNameMatch: none
-            schema:
-              id: openCloudUUID
-          group:
-            schema:
-              id: openCloudUUID
-      virusscan:
-        enabled: enable
-        infectedFileHandling: "abort"
-        scannerType: "clamav"
-        clamavSocket: "tcp://clamav.clamav.svc.cluster.local:3310"
-      emailNotifications:
+        infectedFileHandling: abort
+        scannerType: clamav
+        clamavSocket: tcp://clamav.clamav.svc.cluster.local:3310
+      smtp:
         enabled: false
-        smtp:
-          host: ""
-          port: ""
-          sender: ""
-          authentication: none
-          encryption: ssltls
+        host: ""
+        port: ""
+        sender: ""
+        authentication: none
+        encryption: ssltls
       policies:
-        enabled: enable
+        enabled: true
         policies:
           - fileName: proxy.rego
             content: |
@@ -247,26 +202,40 @@ spec:
                   ext := extensions[_]
                   RESTRICTED_EXTENSIONS_NO_DOT[ext]
               }
-      appsIntegration:
-        enabled: true
-        wopiIntegration:
-          officeSuites:
-            - name: Collabora
-              product: Collabora
-              enabled: true
-              uri: "https://collabora.opencloud.test"
-              insecure: true
-              disableProof: false
-              iconURI: https://collabora.opencloud.test/favicon.ico
-            - name: OnlyOffice
-              product: OnlyOffice
-              enabled: false
-              uri: "https://onlyoffice.opencloud.test"
-              insecure: true
-              disableProof: false
-    insecure:
-      oidcIdpInsecure: true
-      ocHttpApiInsecure: true
+      replicas: 1
+      storage:
+        # Default: decomposed (PVC-backed metadata + blobs, no S3). Switch to "s3"
+        # (external S3) or "posixfs" below to use the alternatives.
+        mode: decomposed
+        # usersDriver: posix       # auto-derived from mode=posixfs; uncomment to override
+        # systemDriver: decomposed # only "decomposed"/"decomposeds3" valid; system has no posix option
+        # posixfs:
+        #   persistence:
+        #     enabled: true
+        #     size: 60Gi
+        #     accessMode: ReadWriteOnce
+        #     # accessMode: ReadWriteMany  # RWX (e.g. CephFS / NFS >=4.2) allows RollingUpdate + multi-replica; fs must support flock + xattrs
+        # --- Decomposed alternative (uncomment to switch) ---
+        decomposed:
+          persistence:
+            enabled: true
+            size: 60Gi
+            # accessMode: ReadWriteOnce  # RWO: only one pod can mount at a time; the chart auto-switches the Deployment strategy to Recreate
+            accessMode: ReadWriteMany  # RWX (e.g. CephFS) allows RollingUpdate + multi-replica
+        # --- External S3 alternative (uncomment to switch) ---
+        # Requires a pre-created Secret with keys `accessKey` and `secretKey`.
+        # Reference it via `storage.s3.external.existingSecret` (below).
+        # s3:
+        #   enabled: true
+        #   external:
+        #     endpoint: https://s3.example.com       # your S3 / Ceph / external MinIO endpoint
+        #     region: default
+        #     existingSecret: s3secret                # Secret with accessKey/secretKey keys
+        #     bucket: opencloud-bucket
+        #     createBucket: true
+    oidc:
+      issuerUrl: https://keycloak.opencloud.test/realms/openCloud
+      clientId: web
     ingress:
       enabled: false
       ingressClassName: nginx
@@ -280,7 +249,6 @@ spec:
         namespace: kube-system
         port: 443
         sectionName: opencloud
-    replicas: 1
 ---
 # ---------------------------------------------------------------------------
 # Second OpenCloud instance (oc2) — shares Keycloak, OpenLDAP and ClamAV with
@@ -393,8 +361,7 @@ spec:
 #             # accessMode: ReadWriteMany  # RWX (e.g. CephFS) allows RollingUpdate + multi-replica
 #         # --- External S3 alternative (uncomment to switch) ---
 #         # Requires a pre-created Secret with keys `accessKey` and `secretKey`.
-#         # Reference it via `storage.s3.external.existingSecret` (below) and
-#         # `secretRefs.s3CredentialsSecretRef` (top-level) so OpenCloud can read it.
+#         # Reference it via `storage.s3.external.existingSecret` (below).
 #         # s3:
 #         #   enabled: true
 #         #   external:
@@ -403,8 +370,6 @@ spec:
 #         #     existingSecret: s3secret                # Secret with accessKey/secretKey keys
 #         #     bucket: opencloud-bucket
 #         #     createBucket: true
-#     # secretRefs:
-#     #   s3CredentialsSecretRef: s3secret  # only needed when storage.mode = s3
 #     oidc:
 #       issuerUrl: https://keycloak.opencloud.test/realms/openCloud
 #       clientId: web

--- a/charts/opencloud/deployments/flux/opencloud/opencloud.yaml
+++ b/charts/opencloud/deployments/flux/opencloud/opencloud.yaml
@@ -103,6 +103,8 @@ spec:
       insecure: true
       migration:
         enabled: false
+      # Keep TUS uploads available until policy and antivirus postprocessing completes.
+      asyncUploads: true
       # Using external Keycloak OIDC + external OpenLDAP: the bundled IDM/idp
       # service must NOT run, so exclude it. Demo users are also disabled.
       createDemoUsers: false
@@ -169,6 +171,20 @@ spec:
               granted = false if {
                   input.request.method == "PUT"
                   pathPrefixes := ["/dav", "/remote.php/webdav", "/remote.php/dav", "/webdav"]
+                  restricted := pathPrefixes[_]
+                  startswith(input.request.path, restricted)
+                  utils.is_extension_restricted(input.resource.name)
+              }
+              granted = false if {
+                  input.request.method == "POST"
+                  pathPrefixes := ["/data", "/dav", "/remote.php/webdav", "/remote.php/dav", "/webdav"]
+                  restricted := pathPrefixes[_]
+                  startswith(input.request.path, restricted)
+                  utils.is_extension_restricted(input.resource.name)
+              }
+              granted = false if {
+                  input.request.method == "PATCH"
+                  pathPrefixes := ["/data", "/dav", "/remote.php/webdav", "/remote.php/dav", "/webdav"]
                   restricted := pathPrefixes[_]
                   startswith(input.request.path, restricted)
                   utils.is_extension_restricted(input.resource.name)

--- a/charts/opencloud/deployments/flux/opencloud/secrets.yaml
+++ b/charts/opencloud/deployments/flux/opencloud/secrets.yaml
@@ -1,29 +1,16 @@
 # OpenCloud instance "oc1" Secrets — placeholder values only, safe for a
 # throwaway test cluster. !! CHANGE ME for anything real.
 #
-# Four Secrets live in the instance namespace:
-#   1. opencloud-oidc-credentials — optional OIDC client-id Secret for
-#                                    external consumers; the chart does not use it.
-#   2. opencloud-oc1-secrets      — optional HelmRelease valuesFrom target
-#                                   (set optional: true on the HelmRelease).
-#   3. ldap-bind-secrets          — read by the OpenCloud chart via
-#                                   opencloud.ldap.secretRef. Password must
-#                                   match openldap/secrets.yaml (openldap ns)
-#                                   when you deploy openldap/.
-#   4. s3secret                   — read by the OpenCloud chart when
-#                                   opencloud.storage.s3.external.existingSecret
-#                                   references it.
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: opencloud-oidc-credentials
-  namespace: opencloud
-  labels:
-    app.kubernetes.io/part-of: opencloud
-type: Opaque
-stringData:
-  client-id: "web"
+# Three Secrets live in the instance namespace:
+#   1. opencloud-oc1-secrets — optional HelmRelease valuesFrom target
+#                              (set optional: true on the HelmRelease).
+#   2. ldap-bind-secrets     — read by the OpenCloud chart via
+#                              opencloud.ldap.secretRef. Password must
+#                              match openldap/secrets.yaml (openldap ns)
+#                              when you deploy openldap/.
+#   3. s3secret              — read by the OpenCloud chart when
+#                              opencloud.storage.s3.external.existingSecret
+#                              references it.
 ---
 apiVersion: v1
 kind: Secret
@@ -50,9 +37,9 @@ stringData:
   reva-ldap-bind-password: admin
   graph-ldap-bind-password: admin
 ---
-# S3 credentials — only needed when opencloud.storage.mode = "s3" and the
-# chart's secretRefs.s3CredentialsSecretRef points at this Secret. Uncomment
-# together with the s3 block in opencloud.yaml to switch back to MinIO.
+# S3 credentials — only needed when opencloud.storage.mode = "s3" and
+# opencloud.storage.s3.external.existingSecret points at this Secret. Uncomment
+# together with the external S3 block in opencloud.yaml.
 # ---
 # apiVersion: v1
 # kind: Secret

--- a/charts/opencloud/deployments/flux/opencloud/secrets.yaml
+++ b/charts/opencloud/deployments/flux/opencloud/secrets.yaml
@@ -2,12 +2,12 @@
 # throwaway test cluster. !! CHANGE ME for anything real.
 #
 # Four Secrets live in the instance namespace:
-#   1. opencloud-oidc-credentials — OIDC client-id / client-secret shared
-#                                    between Keycloak realm and OpenCloud.
+#   1. opencloud-oidc-credentials — optional OIDC client-id Secret for
+#                                    external consumers; the chart does not use it.
 #   2. opencloud-oc1-secrets      — optional HelmRelease valuesFrom target
 #                                   (set optional: true on the HelmRelease).
 #   3. ldap-bind-secrets          — read by the OpenCloud chart via
-#                                   secretRefs.ldapSecretRef. Password must
+#                                   opencloud.ldap.secretRef. Password must
 #                                   match openldap/secrets.yaml (openldap ns)
 #                                   when you deploy openldap/.
 #   4. s3secret                   — read by the OpenCloud chart via
@@ -23,7 +23,6 @@ metadata:
 type: Opaque
 stringData:
   client-id: "web"
-  client-secret: "opencloud-secret-key"
 ---
 apiVersion: v1
 kind: Secret

--- a/charts/opencloud/deployments/flux/opencloud/secrets.yaml
+++ b/charts/opencloud/deployments/flux/opencloud/secrets.yaml
@@ -10,8 +10,9 @@
 #                                   opencloud.ldap.secretRef. Password must
 #                                   match openldap/secrets.yaml (openldap ns)
 #                                   when you deploy openldap/.
-#   4. s3secret                   — read by the OpenCloud chart via
-#                                   secretRefs.s3CredentialsSecretRef.
+#   4. s3secret                   — read by the OpenCloud chart when
+#                                   opencloud.storage.s3.external.existingSecret
+#                                   references it.
 ---
 apiVersion: v1
 kind: Secret

--- a/charts/opencloud/deployments/flux/openldap/openldap.yaml
+++ b/charts/opencloud/deployments/flux/openldap/openldap.yaml
@@ -3,6 +3,38 @@ kind: Namespace
 metadata:
   name: openldap
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: flux
+  namespace: openldap
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: flux-reconciler
+  namespace: openldap
+rules:
+  # Namespace-scoped namespace-admin for Helm reconciliation. This cannot
+  # create or modify cluster-scoped resources such as Namespaces or CRDs.
+  - apiGroups: ["*"]
+    resources: ["*"]
+    verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: flux-reconciler
+  namespace: openldap
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: flux-reconciler
+subjects:
+  - kind: ServiceAccount
+    name: flux
+    namespace: openldap
+---
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
@@ -20,6 +52,7 @@ metadata:
 spec:
   interval: 15m
   timeout: 5m
+  serviceAccountName: flux
   chart:
     spec:
       chart: openldap-stack-ha

--- a/charts/opencloud/templates/_helpers/tpl.yaml
+++ b/charts/opencloud/templates/_helpers/tpl.yaml
@@ -295,3 +295,19 @@ Usage:
         {{- tpl (.value | toYaml) .context }}
     {{- end }}
 {{- end -}}
+
+{{/*
+Render the proxy configuration and overlay separately configured role quotas.
+*/}}
+{{- define "opencloud.proxy.config" -}}
+{{- $proxy := dict -}}
+{{- if empty .Values.opencloud.config.proxy -}}
+  {{- $proxy = fromYaml (tpl (.Files.Get "files/opencloud/proxy.yaml.gotmpl") .) -}}
+{{- else -}}
+  {{- $proxy = fromYaml (include "opencloud.tplvalues.render" (dict "value" .Values.opencloud.config.proxy "context" .)) -}}
+{{- end -}}
+{{- with .Values.opencloud.config.proxyRoleQuotas }}
+  {{- $_ := set $proxy "role_quotas" . -}}
+{{- end }}
+{{- toYaml $proxy -}}
+{{- end -}}

--- a/charts/opencloud/templates/collabora/httproute.yaml
+++ b/charts/opencloud/templates/collabora/httproute.yaml
@@ -10,8 +10,10 @@ spec:
   parentRefs:
     - name: {{ .Values.httpRoute.gateway.name }}
       namespace: {{ .Values.httpRoute.gateway.namespace | default .Release.Namespace }}
-      {{- with .Values.httpRoute.gateway.sectionName }}
-      sectionName: {{ . }}-collabora-http
+      {{- if .Values.httpRoute.gateway.sectionName }}
+      sectionName: {{ .Values.httpRoute.gateway.sectionName }}-collabora-http
+      {{- else if .Values.httpRoute.gateway.create }}
+      sectionName: {{ include "opencloud.fullname" . }}-collabora-http
       {{- end }}
   hostnames:
     - {{ .Values.global.domain.collabora | quote }}
@@ -34,8 +36,10 @@ spec:
   parentRefs:
     - name: {{ .Values.httpRoute.gateway.name }}
       namespace: {{ .Values.httpRoute.gateway.namespace | default .Release.Namespace }}
-      {{- with .Values.httpRoute.gateway.sectionName }}
-      sectionName: {{ . }}-collabora-https
+      {{- if .Values.httpRoute.gateway.sectionName }}
+      sectionName: {{ .Values.httpRoute.gateway.sectionName }}-collabora-https
+      {{- else if .Values.httpRoute.gateway.create }}
+      sectionName: {{ include "opencloud.fullname" . }}-collabora-https
       {{- end }}
   hostnames:
     - {{ .Values.global.domain.collabora | quote }}

--- a/charts/opencloud/templates/collaboration/httproute.yaml
+++ b/charts/opencloud/templates/collaboration/httproute.yaml
@@ -10,8 +10,10 @@ spec:
   parentRefs:
     - name: {{ .Values.httpRoute.gateway.name }}
       namespace: {{ .Values.httpRoute.gateway.namespace | default .Release.Namespace }}
-      {{- with .Values.httpRoute.gateway.sectionName }}
-      sectionName: {{ . }}-wopi-http
+      {{- if .Values.httpRoute.gateway.sectionName }}
+      sectionName: {{ .Values.httpRoute.gateway.sectionName }}-wopi-http
+      {{- else if .Values.httpRoute.gateway.create }}
+      sectionName: {{ include "opencloud.fullname" . }}-wopi-http
       {{- end }}
   hostnames:
     - {{ .Values.global.domain.wopi | quote }}
@@ -34,8 +36,10 @@ spec:
   parentRefs:
     - name: {{ .Values.httpRoute.gateway.name }}
       namespace: {{ .Values.httpRoute.gateway.namespace | default .Release.Namespace }}
-      {{- with .Values.httpRoute.gateway.sectionName }}
-      sectionName: {{ . }}-wopi-https
+      {{- if .Values.httpRoute.gateway.sectionName }}
+      sectionName: {{ .Values.httpRoute.gateway.sectionName }}-wopi-https
+      {{- else if .Values.httpRoute.gateway.create }}
+      sectionName: {{ include "opencloud.fullname" . }}-wopi-https
       {{- end }}
   hostnames:
     - {{ .Values.global.domain.wopi | quote }}

--- a/charts/opencloud/templates/gateway/reference-grant.yaml
+++ b/charts/opencloud/templates/gateway/reference-grant.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.httpRoute.enabled }}
+{{- if and .Values.httpRoute.enabled .Values.httpRoute.gateway.create }}
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: ReferenceGrant
 metadata:

--- a/charts/opencloud/templates/opencloud/configmap.yaml
+++ b/charts/opencloud/templates/opencloud/configmap.yaml
@@ -43,4 +43,16 @@ data:
   search.yaml: |-
 {{- .Files.Get "files/opencloud/search.yaml" | nindent 4 }}
 
+  {{- if .Values.opencloud.policies.enabled }}
+  # Policies service configuration
+  policies.yaml: |-
+    engine:
+      policies:
+        - /etc/opencloud/policies/proxy.rego
+        - /etc/opencloud/policies/postprocessing.rego
+        - /etc/opencloud/policies/utils.rego
+    postprocessing:
+      query: data.postprocessing.granted
+  {{- end }}
+
 {{- end }}

--- a/charts/opencloud/templates/opencloud/configmap.yaml
+++ b/charts/opencloud/templates/opencloud/configmap.yaml
@@ -25,10 +25,10 @@ data:
 
   # Proxy configuration
   proxy.yaml: |-
-{{- if empty .Values.opencloud.config.proxy -}}
+{{- if and (empty .Values.opencloud.config.proxy) (empty .Values.opencloud.config.proxyRoleQuotas) -}}
 {{ tpl (.Files.Get "files/opencloud/proxy.yaml.gotmpl") . | nindent 4 }}
 {{- else -}}
-{{ .Values.opencloud.config.proxy | nindent 4 }}
+{{ include "opencloud.proxy.config" . | nindent 4 }}
 {{- end }}
 
   # Banned password list

--- a/charts/opencloud/templates/opencloud/deployment.yaml
+++ b/charts/opencloud/templates/opencloud/deployment.yaml
@@ -55,6 +55,7 @@ spec:
         checksum/configmap: {{ include (print $.Template.BasePath "/opencloud/configmap.yaml") . | sha256sum }}
         checksum/web-extensions-init: {{ include (print $.Template.BasePath "/opencloud/web-extensions-init.yaml") . | sha256sum }}
         checksum/theme-branding: {{ include (print $.Template.BasePath "/opencloud/theme-branding-configmap.yaml") . | sha256sum }}
+        checksum/policies: {{ include (print $.Template.BasePath "/opencloud/policies-configmap.yaml") . | sha256sum }}
     spec:
       securityContext:
         fsGroup: 1000
@@ -679,6 +680,11 @@ spec:
             - name: config-files
               mountPath: /etc/opencloud/banned-password-list.txt
               subPath: banned-password-list.txt
+            {{- if .Values.opencloud.policies.enabled }}
+            - name: policies
+              mountPath: /etc/opencloud/policies
+              readOnly: true
+            {{- end }}
             {{- if and (.Values.opencloud.nats.external.enabled) (not .Values.opencloud.nats.external.tls.certTrusted) }}
             - name: nats-ca
               mountPath: /etc/opencloud/nats-ca
@@ -722,6 +728,11 @@ spec:
         - name: config-files
           configMap:
             name: {{ include "opencloud.opencloud.fullname" . }}-config
+        {{- if .Values.opencloud.policies.enabled }}
+        - name: policies
+          configMap:
+            name: {{ include "opencloud.fullname" . }}-policies
+        {{- end }}
         - name: theme-branding
           configMap:
             name: {{ include "opencloud.opencloud.fullname" . }}-theme-branding

--- a/charts/opencloud/templates/opencloud/deployment.yaml
+++ b/charts/opencloud/templates/opencloud/deployment.yaml
@@ -61,6 +61,18 @@ spec:
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
       initContainers:
+        {{- if and .Values.tika.enabled (eq .Values.opencloud.searchExtractorType "tika") }}
+        - name: wait-for-tika
+          image: {{ include "opencloud.image" (dict "imageValues" .Values.busybox.image "global" .Values.global) | quote }}
+          imagePullPolicy: {{ include "opencloud.image.pullPolicy" (dict "pullPolicy" .Values.busybox.image.pullPolicy "global" .Values.global) | quote }}
+          command:
+            - sh
+            - -ec
+            - |
+              until wget -q -O /dev/null --timeout=2 http://{{ include "opencloud.tika.fullname" . }}:9998/version; do
+                sleep 2
+              done
+        {{- end }}
         - name: init-config
           image: {{ include "opencloud.image" (dict "imageValues" .Values.busybox.image "global" .Values.global) | quote }}
           imagePullPolicy: {{ include "opencloud.image.pullPolicy" (dict "pullPolicy" .Values.busybox.image.pullPolicy "global" .Values.global) | quote }}

--- a/charts/opencloud/templates/opencloud/deployment.yaml
+++ b/charts/opencloud/templates/opencloud/deployment.yaml
@@ -251,6 +251,8 @@ spec:
               value: data.postprocessing.granted
             {{- end }}
             {{- if or .Values.opencloud.antivirus.enabled .Values.opencloud.policies.enabled }}
+            - name: STORAGE_USERS_DATA_GATEWAY_URL
+              value: "http://{{ include "opencloud.opencloud.fullname" . }}:9200/data"
             - name: POSTPROCESSING_STEPS
               value: {{- if and .Values.opencloud.policies.enabled .Values.opencloud.antivirus.enabled }} "policies,virusscan"{{- else if .Values.opencloud.policies.enabled }} "policies"{{- else }} "virusscan"{{- end }}
             {{- end }}
@@ -273,10 +275,9 @@ spec:
               value: {{ .Values.opencloud.searchExtractorType | quote }}
             - name: SEARCH_EXTRACTOR_TIKA_TIKA_URL
               value: "http://{{ include "opencloud.tika.fullname" . }}:9998"
-            # Must be false — Go default is true, which makes search subscribe to UploadReady
-            # instead of FileUploaded. With sync uploads, FileUploaded is the correct event.
+            # Keep the upload session available while postprocessing runs.
             - name: OC_ASYNC_UPLOADS
-              value: "false"
+              value: {{ .Values.opencloud.asyncUploads | quote }}
             {{- with .Values.opencloud.searchExtractorSizeLimit }}
             - name: SEARCH_CONTENT_EXTRACTION_SIZE_LIMIT
               value: {{ int64 . | quote }}

--- a/charts/opencloud/templates/opencloud/deployment.yaml
+++ b/charts/opencloud/templates/opencloud/deployment.yaml
@@ -207,9 +207,25 @@ spec:
             - name: OC_LOG_PRETTY
               value: {{ .Values.opencloud.logPretty | quote }}
             # Enable services that are not started automatically
-            {{- with .Values.opencloud.additionalServices }}
+            {{- $additional := .Values.opencloud.additionalServices | default (list) }}
+            {{- if .Values.opencloud.antivirus.enabled }}
+              {{- if not (has "antivirus" $additional) }}
+                {{- $additional = append $additional "antivirus" }}
+              {{- end }}
+            {{- end }}
+            {{- if or .Values.opencloud.antivirus.enabled .Values.opencloud.policies.enabled }}
+              {{- if not (has "postprocessing" $additional) }}
+                {{- $additional = append $additional "postprocessing" }}
+              {{- end }}
+            {{- end }}
+            {{- if .Values.opencloud.policies.enabled }}
+              {{- if not (has "policies" $additional) }}
+                {{- $additional = append $additional "policies" }}
+              {{- end }}
+            {{- end }}
+            {{- if gt (len $additional) 0 }}
             - name: OC_ADD_RUN_SERVICES
-              value: {{ join "," . | quote }}
+              value: {{ join "," $additional | quote }}
             {{- end }}
             {{- $exclude := .Values.opencloud.excludeServices | default (list) }}
             {{- if .Values.opencloud.nats.external.enabled }}
@@ -228,6 +244,16 @@ spec:
             # INSECURE: needed if OpenCloud is using self generated certificates
             - name: OC_INSECURE
               value: {{ tpl (toString .Values.opencloud.insecure) . | quote }}
+            {{- if .Values.opencloud.policies.enabled }}
+            - name: PROXY_POLICIES_QUERY
+              value: data.proxy.granted
+            - name: POLICIES_POSTPROCESSING_QUERY
+              value: data.postprocessing.granted
+            {{- end }}
+            {{- if or .Values.opencloud.antivirus.enabled .Values.opencloud.policies.enabled }}
+            - name: POSTPROCESSING_STEPS
+              value: {{- if and .Values.opencloud.policies.enabled .Values.opencloud.antivirus.enabled }} "policies,virusscan"{{- else if .Values.opencloud.policies.enabled }} "policies"{{- else }} "virusscan"{{- end }}
+            {{- end }}
             # Basic auth (only needed when not using Keycloak)
             - name: PROXY_ENABLE_BASIC_AUTH
               value: {{ .Values.opencloud.proxyEnableBasicAuth | quote }}
@@ -680,6 +706,11 @@ spec:
             - name: config-files
               mountPath: /etc/opencloud/banned-password-list.txt
               subPath: banned-password-list.txt
+            {{- if .Values.opencloud.policies.enabled }}
+            - name: config-files
+              mountPath: /etc/opencloud/policies.yaml
+              subPath: policies.yaml
+            {{- end }}
             {{- if .Values.opencloud.policies.enabled }}
             - name: policies
               mountPath: /etc/opencloud/policies

--- a/charts/opencloud/templates/opencloud/httproute.yaml
+++ b/charts/opencloud/templates/opencloud/httproute.yaml
@@ -9,8 +9,10 @@ spec:
   parentRefs:
     - name: {{ .Values.httpRoute.gateway.name }}
       namespace: {{ .Values.httpRoute.gateway.namespace | default .Release.Namespace }}
-      {{- with .Values.httpRoute.gateway.sectionName }}
-      sectionName: {{ . }}-proxy-http
+      {{- if .Values.httpRoute.gateway.sectionName }}
+      sectionName: {{ .Values.httpRoute.gateway.sectionName }}-proxy-http
+      {{- else if .Values.httpRoute.gateway.create }}
+      sectionName: {{ include "opencloud.fullname" . }}-proxy-http
       {{- end }}
   hostnames:
     - {{ include "opencloud.domain" . | quote }}
@@ -32,8 +34,10 @@ spec:
   parentRefs:
     - name: {{ .Values.httpRoute.gateway.name }}
       namespace: {{ .Values.httpRoute.gateway.namespace | default .Release.Namespace }}
-      {{- with .Values.httpRoute.gateway.sectionName }}
-      sectionName: {{ . }}-proxy-https
+      {{- if .Values.httpRoute.gateway.sectionName }}
+      sectionName: {{ .Values.httpRoute.gateway.sectionName }}-proxy-https
+      {{- else if .Values.httpRoute.gateway.create }}
+      sectionName: {{ include "opencloud.fullname" . }}-proxy-https
       {{- end }}
   hostnames:
     - {{ include "opencloud.domain" . | quote }}

--- a/charts/opencloud/tests/antivirus_test.yaml
+++ b/charts/opencloud/tests/antivirus_test.yaml
@@ -39,6 +39,26 @@ tests:
             name: ANTIVIRUS_ENABLED
             value: "true"
 
+  - it: should start antivirus and postprocessing when antivirus is enabled
+    template: opencloud/deployment.yaml
+    set:
+      opencloud:
+        antivirus:
+          enabled: true
+          scannerType: clamav
+          clamavSocket: "tcp://clamav.clamav.svc.cluster.local:3310"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OC_ADD_RUN_SERVICES
+            value: antivirus,postprocessing
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTPROCESSING_STEPS
+            value: virusscan
+
   - it: should set ANTIVIRUS_SCANNER_TYPE when antivirus is enabled
     template: opencloud/deployment.yaml
     set:

--- a/charts/opencloud/tests/antivirus_test.yaml
+++ b/charts/opencloud/tests/antivirus_test.yaml
@@ -58,6 +58,16 @@ tests:
           content:
             name: POSTPROCESSING_STEPS
             value: virusscan
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OC_ASYNC_UPLOADS
+            value: "true"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STORAGE_USERS_DATA_GATEWAY_URL
+            value: http://RELEASE-NAME-opencloud-opencloud:9200/data
 
   - it: should set ANTIVIRUS_SCANNER_TYPE when antivirus is enabled
     template: opencloud/deployment.yaml

--- a/charts/opencloud/tests/antivirus_test.yaml
+++ b/charts/opencloud/tests/antivirus_test.yaml
@@ -4,6 +4,8 @@ templates:
   - opencloud/deployment.yaml
   - opencloud/config-json-configmap.yaml
   - opencloud/configmap.yaml
+  - opencloud/policies-configmap.yaml
+  - opencloud/theme-branding-configmap.yaml
   - opencloud/web-extensions-init.yaml
 
 tests:

--- a/charts/opencloud/tests/e2e/tests/helpers/auth.ts
+++ b/charts/opencloud/tests/e2e/tests/helpers/auth.ts
@@ -85,18 +85,38 @@ export async function login(page: Page) {
     }
   }
 
-  await usernameInput(page).fill(username!);
-  await passwordInput(page).fill(password!);
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    await usernameInput(page).fill(username!);
+    await passwordInput(page).fill(password!);
 
-  const submit = page
-    .locator('button[type="submit"], input[type="submit"], button[name="login"]')
-    .first();
+    const submit = page
+      .locator('button[type="submit"], input[type="submit"], button[name="login"]')
+      .first();
 
-  await expect(submit).toBeVisible();
-  await Promise.all([
-    page.waitForURL(/\/files\//, { timeout: 10000 }),
-    submit.click()
-  ]);
+    await expect(submit).toBeVisible();
+    const responsePromise = page.waitForResponse(
+      (response) =>
+        response.request().method() === 'POST' &&
+        response.url().includes('/signin/v1/identifier/_/logon'),
+      { timeout: 30000 }
+    );
 
-  await expect(personalHeading(page)).toBeVisible();
+    await submit.click();
+    const response = await responsePromise;
+    const body = await response.text().catch(() => '');
+
+    if (response.ok()) {
+      await expect(page).toHaveURL(/\/files\//, { timeout: 30000 });
+      await expect(personalHeading(page)).toBeVisible({ timeout: 30000 });
+      return;
+    }
+
+    if (response.status() !== 500 || attempt === 3) {
+      throw new Error(`OpenCloud login failed with HTTP ${response.status()}: ${body}`);
+    }
+
+    await page.waitForTimeout(attempt * 5000);
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await waitForLoginOrApp(page);
+  }
 }

--- a/charts/opencloud/tests/e2e/tests/spreadsheet.spec.ts
+++ b/charts/opencloud/tests/e2e/tests/spreadsheet.spec.ts
@@ -2,7 +2,7 @@ import { expect, test, type Page } from '@playwright/test';
 import { login, randomLetters } from './helpers/auth';
 
 test('can create spreadsheet, edit A1, save and close', async ({ page, context }) => {
-  test.setTimeout(15_000);
+  test.setTimeout(90_000);
 
   await login(page);
   const fileBaseName = randomLetters(10);

--- a/charts/opencloud/tests/gateway_test.yaml
+++ b/charts/opencloud/tests/gateway_test.yaml
@@ -12,13 +12,23 @@ tests:
       - isKind:
           of: Gateway
 
-  - it: ReferenceGrant resources are created when httpRoute is enabled
+  - it: ReferenceGrant resources are created when the chart creates the Gateway
     template: gateway/reference-grant.yaml
     set:
       httpRoute.enabled: true
+      httpRoute.gateway.create: true
     asserts:
       - hasDocuments:
           count: 2
+
+  - it: ReferenceGrant resources are not created for an external Gateway
+    template: gateway/reference-grant.yaml
+    set:
+      httpRoute.enabled: true
+      httpRoute.gateway.create: false
+    asserts:
+      - hasDocuments:
+          count: 0
 
   - it: Traefik Middleware is created when className is traefik and gateway.create is true
     template: gateway/traefik-middleware.yaml

--- a/charts/opencloud/tests/httproute_test.yaml
+++ b/charts/opencloud/tests/httproute_test.yaml
@@ -4,12 +4,24 @@ tests:
   - it: OpenCloud HTTPRoute is created when httpRoute is enabled
     template: opencloud/httproute.yaml
     set:
-      httpRoute.enabled: true
+      global.tls.enabled: true
+      httpRoute:
+        enabled: true
+        gateway:
+          create: true
     asserts:
       - hasDocuments:
           count: 2
       - isKind:
           of: HTTPRoute
+      - equal:
+          path: spec.parentRefs[0].sectionName
+          value: RELEASE-NAME-opencloud-proxy-http
+        documentIndex: 0
+      - equal:
+          path: spec.parentRefs[0].sectionName
+          value: RELEASE-NAME-opencloud-proxy-https
+        documentIndex: 1
 
   - it: Collabora HTTPRoute is created when httpRoute and collabora are enabled
     template: collabora/httproute.yaml

--- a/charts/opencloud/tests/openldap_test.yaml
+++ b/charts/opencloud/tests/openldap_test.yaml
@@ -4,6 +4,7 @@ templates:
   - opencloud/deployment.yaml
   - opencloud/config-json-configmap.yaml
   - opencloud/configmap.yaml
+  - opencloud/policies-configmap.yaml
   - opencloud/secrets.yaml
   - opencloud/theme-branding-configmap.yaml
   - opencloud/web-extensions-init.yaml

--- a/charts/opencloud/tests/policy_test.yaml
+++ b/charts/opencloud/tests/policy_test.yaml
@@ -1,0 +1,37 @@
+suite: OPA policy integration tests
+templates:
+  - _helpers/tpl.yaml
+  - opencloud/config-json-configmap.yaml
+  - opencloud/configmap.yaml
+  - opencloud/policies-configmap.yaml
+  - opencloud/theme-branding-configmap.yaml
+  - opencloud/web-extensions-init.yaml
+  - opencloud/deployment.yaml
+
+tests:
+  - it: mounts enabled policies and rolls the OpenCloud pod when they change
+    template: opencloud/deployment.yaml
+    set:
+      opencloud:
+        policies:
+          enabled: true
+          policies:
+            - fileName: proxy.rego
+              content: |
+                package proxy
+                default granted := true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: policies
+            mountPath: /etc/opencloud/policies
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: policies
+            configMap:
+              name: RELEASE-NAME-opencloud-policies
+      - exists:
+          path: spec.template.metadata.annotations["checksum/policies"]

--- a/charts/opencloud/tests/policy_test.yaml
+++ b/charts/opencloud/tests/policy_test.yaml
@@ -35,3 +35,45 @@ tests:
               name: RELEASE-NAME-opencloud-policies
       - exists:
           path: spec.template.metadata.annotations["checksum/policies"]
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PROXY_POLICIES_QUERY
+            value: data.proxy.granted
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POLICIES_POSTPROCESSING_QUERY
+            value: data.postprocessing.granted
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTPROCESSING_STEPS
+            value: policies
+
+  - it: configures the policies service with all policy files
+    template: opencloud/configmap.yaml
+    set:
+      opencloud:
+        policies:
+          enabled: true
+          policies:
+            - fileName: proxy.rego
+              content: |
+                package proxy
+                default granted := true
+            - fileName: postprocessing.rego
+              content: |
+                package postprocessing
+                default granted := true
+            - fileName: utils.rego
+              content: |
+                package utils
+                default ok := true
+    asserts:
+      - matchRegex:
+          path: data["policies.yaml"]
+          pattern: "/etc/opencloud/policies/proxy\.rego"
+      - matchRegex:
+          path: data["policies.yaml"]
+          pattern: "query: data\.postprocessing\.granted"

--- a/charts/opencloud/tests/policy_test.yaml
+++ b/charts/opencloud/tests/policy_test.yaml
@@ -50,6 +50,11 @@ tests:
           content:
             name: POSTPROCESSING_STEPS
             value: policies
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STORAGE_USERS_DATA_GATEWAY_URL
+            value: http://RELEASE-NAME-opencloud-opencloud:9200/data
 
   - it: configures the policies service with all policy files
     template: opencloud/configmap.yaml

--- a/charts/opencloud/tests/proxy_test.yaml
+++ b/charts/opencloud/tests/proxy_test.yaml
@@ -1,0 +1,29 @@
+suite: Proxy configuration tests
+templates:
+  - _helpers/tpl.yaml
+  - opencloud/configmap.yaml
+
+tests:
+  - it: merges role quotas without removing built-in proxy policies
+    template: opencloud/configmap.yaml
+    set:
+      opencloud:
+        config:
+          proxyRoleQuotas:
+            d7beeea8-8ff4-406b-8fb6-ab2dd81e6b11: 10737418240
+            2aadd357-682c-406b-8874-293091995fdd: 53687091200
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["proxy.yaml"]
+          pattern: "additional_policies:"
+      - matchRegex:
+          path: data["proxy.yaml"]
+          pattern: "role_quotas:"
+      - matchRegex:
+          path: data["proxy.yaml"]
+          pattern: "d7beeea8-8ff4-406b-8fb6-ab2dd81e6b11: 10737418240"
+      - matchRegex:
+          path: data["proxy.yaml"]
+          pattern: "2aadd357-682c-406b-8874-293091995fdd: 53687091200"

--- a/charts/opencloud/tests/storage_test.yaml
+++ b/charts/opencloud/tests/storage_test.yaml
@@ -4,6 +4,8 @@ templates:
   - opencloud/deployment.yaml
   - opencloud/config-json-configmap.yaml
   - opencloud/configmap.yaml
+  - opencloud/policies-configmap.yaml
+  - opencloud/theme-branding-configmap.yaml
   - opencloud/web-extensions-init.yaml
 
 tests:

--- a/charts/opencloud/values.schema.json
+++ b/charts/opencloud/values.schema.json
@@ -328,6 +328,9 @@
         "createDemoUsers": {
           "type": "boolean"
         },
+        "asyncUploads": {
+          "type": "boolean"
+        },
         "antivirus": {
           "type": "object",
           "properties": {

--- a/charts/opencloud/values.schema.json
+++ b/charts/opencloud/values.schema.json
@@ -569,6 +569,18 @@
               }
             }
           }
+        },
+        "config": {
+          "type": "object",
+          "properties": {
+            "proxyRoleQuotas": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "integer",
+                "minimum": 0
+              }
+            }
+          }
         }
       }
     },

--- a/charts/opencloud/values.schema.json
+++ b/charts/opencloud/values.schema.json
@@ -581,6 +581,32 @@
               }
             }
           }
+        },
+        "policies": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "policies": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "fileName": {
+                    "type": "string"
+                  },
+                  "content": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "fileName",
+                  "content"
+                ]
+              }
+            }
+          }
         }
       }
     },

--- a/charts/opencloud/values.yaml
+++ b/charts/opencloud/values.yaml
@@ -683,6 +683,7 @@ opencloud:
   policies:
     # Enable OPA policies
     enabled: false
+    # Policy files are mounted at /etc/opencloud/policies when enabled.
     # List of policy files
     policies: []
       # Example:

--- a/charts/opencloud/values.yaml
+++ b/charts/opencloud/values.yaml
@@ -435,6 +435,8 @@ opencloud:
   
   # Create demo users (set true for integrated IDM; default admin user is created)
   createDemoUsers: true
+  # Keep upload sessions available while postprocessing policies and antivirus run.
+  asyncUploads: true
   # Additional services to start
   additionalServices: []
   # Services to exclude from starting

--- a/charts/opencloud/values.yaml
+++ b/charts/opencloud/values.yaml
@@ -493,25 +493,24 @@ opencloud:
     appRegistry: {}
     # CSP configuration
     csp: {}
-    # Proxy configuration
-    # ==== Example ====
-    # role_quotas: # Sets default Quota's for roles (in bytes)
-    #   'd7beeea8-8ff4-406b-8fb6-ab2dd81e6b11': 15000000000 # User
-    #   '2aadd357-682c-406b-8874-293091995fdd': 15000000000 # SpaceAdmin
-    #   '71881883-1768-46bd-a24d-a356a2afdf7f': 15000000000 # Admin
-    # 
-    # role_assignment:
-    #   driver: oidc
-    #   oidc_role_mapper:
-    #     role_claim: groups
-    #     role_mapping:
-    #       - role_name: admin                # OpenCloud Role
-    #         claim_value: "authentik Admins" # Authentik Group
-    #       - role_name: spaceadmin
-    #         claim_value: "opencloud-spaces"
-    #       - role_name: user
-    #         claim_value: "opencloud"
+    # Proxy configuration. A non-empty value replaces the built-in proxy YAML.
+    # Example custom proxy configuration:
+    # proxy: |-
+    #   role_assignment:
+    #     driver: oidc
+    #     oidc_role_mapper:
+    #       role_claim: groups
+    #       role_mapping:
+    #         - role_name: admin
+    #           claim_value: "authentik Admins"
+    #         - role_name: spaceadmin
+    #           claim_value: "opencloud-spaces"
+    #         - role_name: user
+    #           claim_value: "opencloud"
     proxy: {}
+    # Role quotas are merged into proxy.yaml without replacing built-in policies.
+    # Values are bytes and keys are OpenCloud role UUIDs.
+    proxyRoleQuotas: {}
     # Banned password list configuration
     # Format: Multi-line string (not YAML array)
     # Use the |- syntax to preserve line breaks


### PR DESCRIPTION
## Summary

- Add `opencloud.config.proxyRoleQuotas` as a dedicated chart value.
- Merge role quotas into the built-in or custom proxy configuration without removing `additional_policies`.
- Migrate the Flux example from the ignored top-level `quotas.roles` path.
- Remove the unused external-user-management `adminUUID` value and stale LDAP secret reference.
- Add schema documentation and a regression test for the proxy merge.

## Validation

- `helm lint charts/opencloud`
- `helm unittest -f tests/proxy_test.yaml charts/opencloud`
- `kubectl apply --dry-run=client -f charts/opencloud/deployments/flux/opencloud/opencloud.yaml`
- `git diff --check`

The full existing unit suite still contains unrelated baseline failures involving missing `theme-branding-configmap` test template inclusions and one Collabora assertion.