### PR TITLE
fix: add Flux reconciler RBAC for Keycloak

### DIFF
--- a/charts/opencloud/deployments/flux/keycloak/keycloak.yaml
+++ b/charts/opencloud/deployments/flux/keycloak/keycloak.yaml
@@ -3,6 +3,38 @@ kind: Namespace
 metadata:
   name: keycloak
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: flux
+  namespace: keycloak
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: flux-reconciler
+  namespace: keycloak
+rules:
+  # Namespace-scoped namespace-admin for Helm reconciliation. This cannot
+  # create or modify cluster-scoped resources such as Namespaces or CRDs.
+  - apiGroups: ["*"]
+    resources: ["*"]
+    verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: flux-reconciler
+  namespace: keycloak
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: flux-reconciler
+subjects:
+  - kind: ServiceAccount
+    name: flux
+    namespace: keycloak
+---
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: OCIRepository
 metadata:

--- a/charts/opencloud/deployments/flux/opencloud/opencloud.yaml
+++ b/charts/opencloud/deployments/flux/opencloud/opencloud.yaml
@@ -170,6 +170,7 @@ spec:
       ldapServerWriteEnabled: true
       proxyAutoprovisionAccounts: true
       proxyAutoprovisionClaimUsername: sub
+      proxyUserOidcClaim: sub
       proxyRoleAssignmentDriver: oidc
       proxyRoleAssignmentOidcClaim: roles
       config:


### PR DESCRIPTION
## Summary
- add a namespace-scoped Flux reconciler ServiceAccount in the Keycloak namespace
- grant the reconciler namespace-admin permissions through a Role and RoleBinding

This allows the Keycloak Helm reconciliation to manage namespace-scoped resources without granting cluster-scoped permissions.