### PR TITLE
feat(httproute): allow exact sectionName overrides for external gateways

### DIFF
--- a/charts/opencloud/README.md
+++ b/charts/opencloud/README.md
@@ -574,7 +574,9 @@ This chart includes HTTPRoute resources that can be used to expose the OpenCloud
 | `httpRoute.enabled` | Enable HTTPRoutes | `false` |
 | `httpRoute.gateway.name` | Gateway name | `opencloud-gateway` |
 | `httpRoute.gateway.namespace` | Gateway namespace | `""` (defaults to Release.Namespace) |
-| `httpRoute.gateway.sectionName` | Gateway section name | `""` (defaults to multiple route-specific section names for the routes listed below) |
+| `httpRoute.gateway.sectionName` | Gateway section name prefix | `""` (defaults to multiple route-specific section names for the routes listed below) |
+| `httpRoute.gateway.exactSectionName` | Exact Gateway section name for all generated HTTPRoutes on an external Gateway | `""` |
+| `httpRoute.gateway.httpSectionName` | Exact Gateway section name for HTTP redirect routes on an external Gateway | `""` |
 | `httpRoute.opencloud.routeName` | Name of the OpenCloud HTTPS HTTPRoute | `""` (defaults to `{{ release-name }}-httproute`) |
 | `httpRoute.opencloud.redirectRouteName` | Name of the OpenCloud HTTP→HTTPS redirect HTTPRoute | `""` (defaults to `{{ release-name }}-http-redirect`) |
 | `httpRoute.collabora.routeName` | Name of the Collabora HTTPS HTTPRoute | `""` (defaults to `{{ release-name }}-collabora-httproute`) |
@@ -604,7 +606,12 @@ The HTTPRoute resource names can be customized via the `httpRoute.<component>.ro
 
 > **Note:** This chart no longer manages a Keycloak HTTPRoute. When using external OIDC, deploy and manage the Keycloak HTTPRoute alongside your Keycloak deployment (see `deployments/flux/keycloak/keycloak.yaml` for an example using `extraManifests`).
 
-All HTTPRoutes use the Gateway specified by `httpRoute.gateway.name` and `httpRoute.gateway.namespace`. If `httpRoute.gateway.sectionName` is set, all routes use `${sectionName}-<component>-http/https` as their listener section names (useful when `httpRoute.gateway.create` is `false` and you reference an existing gateway). If `httpRoute.gateway.sectionName` is empty and `httpRoute.gateway.create` is `true`, the chart creates the Gateway with per-component listeners.
+All HTTPRoutes use the Gateway specified by `httpRoute.gateway.name` and `httpRoute.gateway.namespace`. The listener section names are chosen in this order:
+
+1. If `httpRoute.gateway.httpSectionName` is set and you reuse an external Gateway (`httpRoute.gateway.create=false`), HTTP redirect routes use that exact listener name.
+2. If `httpRoute.gateway.exactSectionName` is set and you reuse an external Gateway, all generated HTTPRoutes use that exact listener name.
+3. If `httpRoute.gateway.sectionName` is set, the chart treats it as a prefix and appends the route-specific suffixes, for example `${sectionName}-proxy-https` or `${sectionName}-collabora-http`.
+4. If none of the overrides are set and `httpRoute.gateway.create` is `true`, the chart creates the Gateway with its default per-component listener names.
 
 ## Setting Up Gateway API with Talos, Cilium, and cert-manager
 

--- a/charts/opencloud/templates/_helpers/tpl.yaml
+++ b/charts/opencloud/templates/_helpers/tpl.yaml
@@ -127,27 +127,31 @@ Create a fully qualified Tika name.
 Return the default Gateway listener section name for a route.
 */}}
 {{- define "opencloud.httpRoute.defaultSectionName" -}}
-{{- $route := index . "route" -}}
-{{- if index . "tlsEnabled" -}}
-{{- printf "%s-https" $route -}}
-{{- else -}}
-{{- printf "%s-http" $route -}}
-{{- end -}}
+{{- $root := index . "root" -}}
+{{- $suffix := index . "suffix" -}}
+{{- printf "%s-%s" (include "opencloud.fullname" $root) $suffix -}}
 {{- end -}}
 
 {{/*
 Return the sectionName for an HTTPRoute.
-Uses a custom gateway.sectionName when set. Otherwise, when the chart creates
-the Gateway, fall back to the route-specific listener name. If no Gateway is
+For external Gateways, a redirect route can use gateway.httpSectionName and all
+routes can use gateway.exactSectionName as exact listener names. Otherwise,
+gateway.sectionName keeps the legacy prefix behavior. When the chart creates
+the Gateway, fall back to the chart-managed listener name. If no Gateway is
 created, leave sectionName empty so an external Gateway can choose freely.
 */}}
 {{- define "opencloud.httpRoute.sectionName" -}}
 {{- $root := index . "root" -}}
-{{- $route := index . "route" -}}
-{{- if $root.Values.httpRoute.gateway.sectionName -}}
-{{- $root.Values.httpRoute.gateway.sectionName -}}
+{{- $suffix := index . "suffix" -}}
+{{- $isHttpRedirect := index . "isHttpRedirect" | default false -}}
+{{- if and (not $root.Values.httpRoute.gateway.create) $isHttpRedirect $root.Values.httpRoute.gateway.httpSectionName -}}
+{{- $root.Values.httpRoute.gateway.httpSectionName -}}
+{{- else if and (not $root.Values.httpRoute.gateway.create) $root.Values.httpRoute.gateway.exactSectionName -}}
+{{- $root.Values.httpRoute.gateway.exactSectionName -}}
+{{- else if $root.Values.httpRoute.gateway.sectionName -}}
+{{- printf "%s-%s" $root.Values.httpRoute.gateway.sectionName $suffix -}}
 {{- else if $root.Values.httpRoute.gateway.create -}}
-{{- include "opencloud.httpRoute.defaultSectionName" (dict "route" $route "tlsEnabled" $root.Values.global.tls.enabled) -}}
+{{- include "opencloud.httpRoute.defaultSectionName" (dict "root" $root "suffix" $suffix) -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/opencloud/templates/collabora/httproute.yaml
+++ b/charts/opencloud/templates/collabora/httproute.yaml
@@ -10,10 +10,9 @@ spec:
   parentRefs:
     - name: {{ .Values.httpRoute.gateway.name }}
       namespace: {{ .Values.httpRoute.gateway.namespace | default .Release.Namespace }}
-      {{- if .Values.httpRoute.gateway.sectionName }}
-      sectionName: {{ .Values.httpRoute.gateway.sectionName }}-collabora-http
-      {{- else if .Values.httpRoute.gateway.create }}
-      sectionName: {{ include "opencloud.fullname" . }}-collabora-http
+      {{- $sectionName := include "opencloud.httpRoute.sectionName" (dict "root" . "suffix" "collabora-http" "isHttpRedirect" true) }}
+      {{- if $sectionName }}
+      sectionName: {{ $sectionName }}
       {{- end }}
   hostnames:
     - {{ .Values.global.domain.collabora | quote }}
@@ -36,10 +35,9 @@ spec:
   parentRefs:
     - name: {{ .Values.httpRoute.gateway.name }}
       namespace: {{ .Values.httpRoute.gateway.namespace | default .Release.Namespace }}
-      {{- if .Values.httpRoute.gateway.sectionName }}
-      sectionName: {{ .Values.httpRoute.gateway.sectionName }}-collabora-https
-      {{- else if .Values.httpRoute.gateway.create }}
-      sectionName: {{ include "opencloud.fullname" . }}-collabora-https
+      {{- $sectionName := include "opencloud.httpRoute.sectionName" (dict "root" . "suffix" "collabora-https") }}
+      {{- if $sectionName }}
+      sectionName: {{ $sectionName }}
       {{- end }}
   hostnames:
     - {{ .Values.global.domain.collabora | quote }}

--- a/charts/opencloud/templates/opencloud/httproute.yaml
+++ b/charts/opencloud/templates/opencloud/httproute.yaml
@@ -9,10 +9,9 @@ spec:
   parentRefs:
     - name: {{ .Values.httpRoute.gateway.name }}
       namespace: {{ .Values.httpRoute.gateway.namespace | default .Release.Namespace }}
-      {{- if .Values.httpRoute.gateway.sectionName }}
-      sectionName: {{ .Values.httpRoute.gateway.sectionName }}-proxy-http
-      {{- else if .Values.httpRoute.gateway.create }}
-      sectionName: {{ include "opencloud.fullname" . }}-proxy-http
+      {{- $sectionName := include "opencloud.httpRoute.sectionName" (dict "root" . "suffix" "proxy-http" "isHttpRedirect" true) }}
+      {{- if $sectionName }}
+      sectionName: {{ $sectionName }}
       {{- end }}
   hostnames:
     - {{ include "opencloud.domain" . | quote }}
@@ -34,10 +33,9 @@ spec:
   parentRefs:
     - name: {{ .Values.httpRoute.gateway.name }}
       namespace: {{ .Values.httpRoute.gateway.namespace | default .Release.Namespace }}
-      {{- if .Values.httpRoute.gateway.sectionName }}
-      sectionName: {{ .Values.httpRoute.gateway.sectionName }}-proxy-https
-      {{- else if .Values.httpRoute.gateway.create }}
-      sectionName: {{ include "opencloud.fullname" . }}-proxy-https
+      {{- $sectionName := include "opencloud.httpRoute.sectionName" (dict "root" . "suffix" "proxy-https") }}
+      {{- if $sectionName }}
+      sectionName: {{ $sectionName }}
       {{- end }}
   hostnames:
     - {{ include "opencloud.domain" . | quote }}

--- a/charts/opencloud/tests/httproute_test.yaml
+++ b/charts/opencloud/tests/httproute_test.yaml
@@ -23,6 +23,52 @@ tests:
           value: RELEASE-NAME-opencloud-proxy-https
         documentIndex: 1
 
+  - it: OpenCloud HTTPRoutes keep the legacy sectionName prefix behavior
+    template: opencloud/httproute.yaml
+    set:
+      httpRoute.enabled: true
+      httpRoute.gateway.sectionName: shared
+    asserts:
+      - equal:
+          path: spec.parentRefs[0].sectionName
+          value: shared-proxy-http
+        documentIndex: 0
+      - equal:
+          path: spec.parentRefs[0].sectionName
+          value: shared-proxy-https
+        documentIndex: 1
+
+  - it: OpenCloud HTTPRoutes can share one exact external listener name
+    template: opencloud/httproute.yaml
+    set:
+      httpRoute.enabled: true
+      httpRoute.gateway.exactSectionName: shared-listener
+    asserts:
+      - equal:
+          path: spec.parentRefs[0].sectionName
+          value: shared-listener
+        documentIndex: 0
+      - equal:
+          path: spec.parentRefs[0].sectionName
+          value: shared-listener
+        documentIndex: 1
+
+  - it: OpenCloud redirect routes can use a dedicated exact HTTP listener name
+    template: opencloud/httproute.yaml
+    set:
+      httpRoute.enabled: true
+      httpRoute.gateway.exactSectionName: shared-https
+      httpRoute.gateway.httpSectionName: shared-http
+    asserts:
+      - equal:
+          path: spec.parentRefs[0].sectionName
+          value: shared-http
+        documentIndex: 0
+      - equal:
+          path: spec.parentRefs[0].sectionName
+          value: shared-https
+        documentIndex: 1
+
   - it: Collabora HTTPRoute is created when httpRoute and collabora are enabled
     template: collabora/httproute.yaml
     set:
@@ -33,6 +79,22 @@ tests:
           count: 2
       - isKind:
           of: HTTPRoute
+
+  - it: Collabora HTTPRoutes can share one exact external listener name
+    template: collabora/httproute.yaml
+    set:
+      httpRoute.enabled: true
+      collabora.enabled: true
+      httpRoute.gateway.exactSectionName: shared-listener
+    asserts:
+      - equal:
+          path: spec.parentRefs[0].sectionName
+          value: shared-listener
+        documentIndex: 0
+      - equal:
+          path: spec.parentRefs[0].sectionName
+          value: shared-listener
+        documentIndex: 1
 
   - it: Collaboration HTTPRoute is created when httpRoute and collaboration are enabled
     template: collaboration/httproute.yaml

--- a/charts/opencloud/values.schema.json
+++ b/charts/opencloud/values.schema.json
@@ -640,6 +640,9 @@
             "sectionName": {
               "type": "string"
             },
+            "exactSectionName": {
+              "type": "string"
+            },
             "httpSectionName": {
               "type": "string"
             }

--- a/charts/opencloud/values.yaml
+++ b/charts/opencloud/values.yaml
@@ -719,9 +719,18 @@ httpRoute:
     className: cilium
     # Gateway namespace (defaults to Release.Namespace)
     namespace: ""
-    # Gateway section name (applies to all routes). If set to a non-empty value, this overrides the default component-specific section names (e.g., opencloud-https) for all routes. If left empty, the defaults are used.
+    # Gateway section name prefix. If set to a non-empty value, the chart keeps
+    # appending the route-specific suffixes (for example "<prefix>-proxy-https"
+    # or "<prefix>-collabora-http"). This works with both chart-managed and
+    # external Gateways.
     sectionName: ""
-    # Gateway HTTP section name for redirect routes. If set to a non-empty value, this overrides the default component-specific HTTP section names (e.g., opencloud-proxy-http) for redirect routes. If left empty, the defaults are used.
+    # Exact Gateway section name for all generated HTTPRoutes when reusing an
+    # external Gateway (httpRoute.gateway.create=false). If left empty, the
+    # chart uses sectionName as a prefix or its default route-specific names.
+    exactSectionName: ""
+    # Exact Gateway HTTP section name for redirect routes when reusing an
+    # external Gateway (httpRoute.gateway.create=false). If set, it overrides
+    # exactSectionName for redirect routes only.
     httpSectionName: ""
     # Gateway annotations
     annotations:


### PR DESCRIPTION
Keep the existing sectionName prefix behavior for generated listener names.
Add exactSectionName for shared external Gateway listeners and
httpSectionName for redirect-specific HTTP listeners.
Update docs, schema, and HTTPRoute tests.