### PR TITLE
Preserve storage users mount ID during legacy migration

### DIFF
--- a/charts/opencloud/templates/opencloud/migration-job.yaml
+++ b/charts/opencloud/templates/opencloud/migration-job.yaml
@@ -126,17 +126,31 @@ spec:
                 }
               ' "${CONFIG_FILE}")"
 
+              STORAGE_USERS_MOUNT_ID="$(awk '
+                /^storage_users:[[:space:]]*$/ { in_storage_users=1; next }
+                in_storage_users && /^[^[:space:]]/ { in_storage_users=0 }
+                in_storage_users && /^[[:space:]]+mount_id:[[:space:]]*/ {
+                  sub(/^[[:space:]]+mount_id:[[:space:]]*/, "")
+                  gsub(/^"|"$/, "")
+                  print
+                  exit
+                }
+              ' "${CONFIG_FILE}")"
+
               [ -n "${IDM_REVA_PASSWORD}" ] || (echo "Missing idm.service_user_passwords.reva_password" && exit 1)
               [ -n "${IDM_SERVICE_PASSWORD}" ] || (echo "Missing idm.service_user_passwords.idm_password" && exit 1)
               [ -n "${IDP_LDAP_BIND_PASSWORD}" ] || (echo "Missing idp.ldap.bind_password" && exit 1)
+              [ -n "${STORAGE_USERS_MOUNT_ID}" ] || (echo "Missing storage_users.mount_id" && exit 1)
 
               b64_idm_reva="$(printf '%s' "${IDM_REVA_PASSWORD}" | base64 | tr -d '\n')"
               b64_idm_service="$(printf '%s' "${IDM_SERVICE_PASSWORD}" | base64 | tr -d '\n')"
               b64_idp_ldap="$(printf '%s' "${IDP_LDAP_BIND_PASSWORD}" | base64 | tr -d '\n')"
+              b64_storage_users_mount_id="$(printf '%s' "${STORAGE_USERS_MOUNT_ID}" | base64 | tr -d '\n')"
 
               kubectl -n "{{ .Release.Namespace }}" patch secret "{{ $targetSecret }}" --type='json' -p="[{\"op\":\"add\",\"path\":\"/data/idmRevaServicePassword\",\"value\":\"${b64_idm_reva}\"}]"
               kubectl -n "{{ .Release.Namespace }}" patch secret "{{ $targetSecret }}" --type='json' -p="[{\"op\":\"add\",\"path\":\"/data/idmServicePassword\",\"value\":\"${b64_idm_service}\"}]"
               kubectl -n "{{ .Release.Namespace }}" patch secret "{{ $targetSecret }}" --type='json' -p="[{\"op\":\"add\",\"path\":\"/data/idmIdpServicePassword\",\"value\":\"${b64_idp_ldap}\"}]"
+              kubectl -n "{{ .Release.Namespace }}" patch secret "{{ $targetSecret }}" --type='json' -p="[{\"op\":\"add\",\"path\":\"/data/storageUsersMountID\",\"value\":\"${b64_storage_users_mount_id}\"}]"
 
               kubectl -n "{{ .Release.Namespace }}" rollout restart deployment "{{ $targetDeployment }}"
           volumeMounts:


### PR DESCRIPTION
Migrate `storage_users.mount_id` from the legacy `opencloud.yaml` into the init Secret. This preserves the storage provider identity across upgrades and avoids breaking existing desktop sync configurations.