### PR TITLE
option to use HTTPS protocol when TLS is provided externally

### DIFF
--- a/charts/opencloud/README.md
+++ b/charts/opencloud/README.md
@@ -255,6 +255,7 @@ This will prepend `my-registry.com/` to all image references in the chart. For e
 | `global.domain.collabora` | Domain for Collabora | `collabora.opencloud.test` |
 | `global.domain.companion` | Domain for Companion | `companion.opencloud.test` |
 | `global.domain.wopi` | Domain for WOPI server | `wopiserver.opencloud.test` |
+| `global.tls.external` | Indicate TLS will be provided externally. Configures opencloud to use "https://" URLS | `true` |
 | `global.tls.enabled` | Enable TLS (set to false when using gateway TLS termination externally) | `false` |
 | `global.tls.secretName` | secretName for TLS certificate | `""` |
 | `global.storage.storageClass` | Storage class for persistent volumes | `""` |

--- a/charts/opencloud/files/opencloud/config.json.gotmpl
+++ b/charts/opencloud/files/opencloud/config.json.gotmpl
@@ -1,5 +1,5 @@
 {
-  "server": "{{ if .Values.global.tls.enabled }}https{{ else }}http{{ end }}://{{ include "opencloud.domain" . }}",
+  "server": "{{ if or .Values.global.tls.enabled .Values.global.tls.external }}https{{ else }}http{{ end }}://{{ include "opencloud.domain" . }}",
   "theme": {{ .Values.opencloud.config.theme | quote }},
   "version": "0.1.0"
 }

--- a/charts/opencloud/templates/opencloud/deployment.yaml
+++ b/charts/opencloud/templates/opencloud/deployment.yaml
@@ -207,7 +207,7 @@ spec:
             # OpenCloud URL
             {{- /* The built-in IDP requires an https issuer URL. With Gateway TLS termination the public URL is https even when internal TLS (global.tls.enabled) is off, so only fall back to http when the IDP is excluded (external OIDC). */}}
             - name: OC_URL
-              value: "{{ if or .Values.global.tls.enabled (not (has "idp" (.Values.opencloud.excludeServices | default (list)))) }}https{{ else }}http{{ end }}://{{ include "opencloud.domain" . }}"
+              value: "{{ if or .Values.global.tls.enabled .Values.global.tls.external (not (has "idp" (.Values.opencloud.excludeServices | default (list)))) }}https{{ else }}http{{ end }}://{{ include "opencloud.domain" . }}"
             # Available roles
             - name: GRAPH_AVAILABLE_ROLES
               value: {{ .Values.opencloud.graphAvailableRoles | quote }}

--- a/charts/opencloud/templates/opencloud/deployment.yaml
+++ b/charts/opencloud/templates/opencloud/deployment.yaml
@@ -206,8 +206,8 @@ spec:
           env:
             # OpenCloud URL
             {{- /* The built-in IDP requires an https issuer URL. With Gateway TLS termination the public URL is https even when internal TLS (global.tls.enabled) is off, so only fall back to http when the IDP is excluded (external OIDC). */}}
-            - name: OC_URL
-              value: "{{ if or .Values.global.tls.enabled .Values.global.tls.external (not (has "idp" (.Values.opencloud.excludeServices | default (list)))) }}https{{ else }}http{{ end }}://{{ include "opencloud.domain" . }}"
+            - name: OC_URL  
+              value: "{{ if or .Values.global.tls.enabled .Values.global.tls.external }}https{{ else if (not (has "idp" (.Values.opencloud.excludeServices | default (list)))) }}https{{ else }}http{{ end }}://{{ include "opencloud.domain" . }}"
             # Available roles
             - name: GRAPH_AVAILABLE_ROLES
               value: {{ .Values.opencloud.graphAvailableRoles | quote }}

--- a/charts/opencloud/values.schema.json
+++ b/charts/opencloud/values.schema.json
@@ -29,6 +29,9 @@
         "tls": {
           "type": "object",
           "properties": {
+            "external": {
+              "type": "boolean"
+            },
             "enabled": {
               "type": "boolean"
             },

--- a/charts/opencloud/values.yaml
+++ b/charts/opencloud/values.yaml
@@ -31,6 +31,8 @@ global:
 
   # TLS settings for secure connections
   tls:
+    # External gateway uses TLS (set to false if not providing HTTPS endpoints for users)
+    external: true
     # Enable TLS (set to false when using gateway TLS termination externally)
     enabled: false
     # secretName for TLS certificate


### PR DESCRIPTION
With the 3.0.0 update, opencloud was set to use HTTP URLS for the web interface when internal TLS was disabled and/or the internal IDP was disabled. This isn't always desirable if TLS is provided externally.

this caused CORS and script source issues when using an external proxy to provide TLS services to a users.

I added the .Values.opencloud.tls.external value (true by default) to instruct opencloud to use HTTPS urls even if it wasn't configured internally. 