### PR TITLE
fix(identity): add opencloud.ldap.keepIdm for external OIDC without OpenLDAP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 <!-- release-bot:start -->
 
+## [Unreleased]
+
+### Fixes
+- Add `opencloud.ldap.keepIdm` so external OIDC can keep the bundled IDM (LibreIDM) instead of OpenLDAP. Default is unchanged: `excludeServices: [idp]` still points `OC_LDAP_*` at `openldap.openldap.svc`.
+
+### Upgrade notes
+- None. Existing OpenLDAP installs that exclude `idp` keep working with no new values.
+- Authentik / Authelia (external OIDC, no OpenLDAP): set `oidc.issuerUrl`, `excludeServices: [idp]`, and `opencloud.ldap.keepIdm: true`. Do **not** exclude `idm`.
+
 ## [3.0.0] - 2026-08-30
 
 ### Breaking Changes

--- a/charts/opencloud/README.md
+++ b/charts/opencloud/README.md
@@ -289,7 +289,9 @@ This will prepend `my-registry.com/` to all image references in the chart. For e
 | `opencloud.adminPassword` | Admin password | `admin` |
 | `opencloud.createDemoUsers` | Create demo users (default `true` for integrated IDM) | `true` |
 | `opencloud.asyncUploads` | Keep upload sessions available during postprocessing | `true` |
-| `opencloud.excludeServices` | Services to exclude from starting (set `["idp"]` when using external OIDC). The external LDAP env vars (`OC_LDAP_*`, `GRAPH_LDAP_*`, `FRONTEND_LDAP_SERVER_WRITE_ENABLED`) and the external LDAP bind secret (`opencloud.ldap.secretRef`, default `<release-name>-opencloud-ldap`, chart-generated from `opencloud.ldap.adminPassword`) are only used when `idp` is excluded; with the built-in IDP running they are omitted and the bind passwords come from the generated init secret. | `[]` |
+| `opencloud.excludeServices` | Services to exclude from starting. Set `["idp"]` to use an external OIDC provider. Set `["idm"]` when an external LDAP server replaces the bundled IDM. | `[]` |
+| `opencloud.ldap.keepIdm` | Keep the bundled IDM as the user directory when `idp` is excluded. `false`: `OC_LDAP_*` points at `opencloud.ldap.uri`. `true`: accounts stay in IDM. | `false` |
+| `opencloud.ldap.secretRef` | Existing Secret with `reva-ldap-bind-password` / `graph-ldap-bind-password` (used when `idp` is excluded and `ldap.keepIdm` is false) | `""` |
 | `opencloud.theme.urls.imprint` | Imprint URL shown in the web UI footer (empty = hidden) | `https://opencloud.eu/en/legal-notice` |
 | `opencloud.theme.urls.privacy` | Privacy policy URL shown in the web UI footer (empty = hidden) | `https://opencloud.eu/en/data-protection-notice` |
 | `opencloud.theme.urls.accessibility` | Accessibility statement URL shown in the web UI footer (empty = hidden) | `https://opencloud.eu/en/accessibility-statement` |
@@ -463,13 +465,20 @@ opencloud:
 
 
 
-The chart uses the **integrated IDM** by default. To use an external OIDC provider, set `oidc.issuerUrl` and exclude the `idp` service.
+The chart uses the **bundled IDP** (LibreGraph Connect) and **bundled IDM** (LibreIDM LDAP) by default. Those are two different services:
+
+| Piece | What it is | Bundled process | External replacement |
+| ----- | ---------- | --------------- | -------------------- |
+| **IDP** | Login (OIDC) | `idp` | Authentik, Keycloak, Authelia, Auth0, … (`oidc.issuerUrl` + `excludeServices: [idp]`) |
+| **IDM** | User directory (LDAP) | `idm` | OpenLDAP / AD (`OC_LDAP_*` + usually `excludeServices: [idm]`) |
+
+When `excludeServices` contains `idp` and `ldap.keepIdm` is `false`, the chart sets `OC_LDAP_*` from `opencloud.ldap` (default `ldaps://openldap.openldap.svc.cluster.local:636`). Set `opencloud.ldap.keepIdm: true` to keep accounts in the bundled IDM instead.
 
 ### OIDC Settings
 
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
-| `oidc.issuerUrl` | OIDC Issuer URL (leave empty for integrated IDM) | `""` |
+| `oidc.issuerUrl` | OIDC Issuer URL (leave empty for the bundled IDP) | `""` |
 | `oidc.clientId` | OIDC Client ID | `"web"` |
 | `oidc.accountUrl` | Account management URL (optional; derived from `issuerUrl` if empty) | `""` |
 | `oidc.oidcIdpInsecure` | Disable TLS certificate validation for OIDC provider | `false` |
@@ -483,7 +492,33 @@ The chart uses the **integrated IDM** by default. To use an external OIDC provid
 | `oidc.cors.allowCredentials` | Allow credentials | `"true"` |
 | `oidc.cors.maxAge` | Max age in seconds | `"3600"` |
 
-#### Example: Using External OIDC Provider
+#### Example: External OIDC + bundled IDM
+
+Login goes to the external OIDC provider. Users autoprovision into IDM.
+
+```yaml
+oidc:
+  issuerUrl: "https://auth.example.com/application/o/opencloud/"
+  clientId: "web"
+  accountUrl: "https://auth.example.com/if/user/#/settings"
+  scope: "openid profile email groups"
+
+opencloud:
+  createDemoUsers: false
+  ldap:
+    keepIdm: true
+  excludeServices:
+    - idp
+  proxyOidcAccessTokenVerifyMethod: "none"
+  proxyRoleAssignmentOidcClaim: "groups"
+  proxyAutoprovisionClaimUsername: "preferred_username"
+  oidc:
+    scope: "openid profile email groups"
+```
+
+#### Example: External OIDC + OpenLDAP
+
+Excluding `idp` with `ldap.keepIdm: false` points LDAP at `opencloud.ldap.uri`. Deploy OpenLDAP yourself (the chart does not ship it).
 
 ```yaml
 oidc:
@@ -494,8 +529,15 @@ oidc:
 opencloud:
   createDemoUsers: false
   excludeServices:
-    - "idp"
+    - idp
+    - idm
+  ldap:
+    uri: "ldaps://openldap.openldap.svc.cluster.local:636"
+    bindDN: "cn=admin,dc=opencloud,dc=eu"
+    adminPassword: "changeme"
 ```
+
+> **Note:** Silent token renewal in the Web UI uses a hidden iframe against the IdP. If the IdP sends `X-Frame-Options: DENY` (Authentik default), configure `frame-ancestors` on the **IdP** reverse proxy to allow the OpenCloud origin. That is not a chart setting.
 
 ### Collabora Settings
 

--- a/charts/opencloud/templates/opencloud/deployment.yaml
+++ b/charts/opencloud/templates/opencloud/deployment.yaml
@@ -410,7 +410,7 @@ spec:
               value: {{ printf "%s/.well-known/openid-configuration" (include "opencloud.oidc.issuer" .) | quote }}
             - name: WEB_OIDC_SCOPE
               value: {{ .Values.opencloud.oidc.scope | quote }}
-            {{- /* OC_LDAP_* against opencloud.ldap.uri when idp is excluded and ldap.keepIdm is false. */}}
+            {{- /* OC_LDAP_* against opencloud.ldap.uri when idp is excluded and opencloud.ldap.keepIdm is false. */}}
             {{- $useExternalLdap := and (has "idp" (.Values.opencloud.excludeServices | default (list))) (not .Values.opencloud.ldap.keepIdm) }}
             {{- if $useExternalLdap }}
             - name: OC_LDAP_SERVER_WRITE_ENABLED

--- a/charts/opencloud/templates/opencloud/deployment.yaml
+++ b/charts/opencloud/templates/opencloud/deployment.yaml
@@ -410,8 +410,9 @@ spec:
               value: {{ printf "%s/.well-known/openid-configuration" (include "opencloud.oidc.issuer" .) | quote }}
             - name: WEB_OIDC_SCOPE
               value: {{ .Values.opencloud.oidc.scope | quote }}
-            {{- /* External LDAP settings are only needed when the built-in IDP is excluded (external OIDC/LDAP setup) */}}
-            {{- if has "idp" (.Values.opencloud.excludeServices | default (list)) }}
+            {{- /* OC_LDAP_* against opencloud.ldap.uri when idp is excluded and ldap.keepIdm is false. */}}
+            {{- $useExternalLdap := and (has "idp" (.Values.opencloud.excludeServices | default (list))) (not .Values.opencloud.ldap.keepIdm) }}
+            {{- if $useExternalLdap }}
             - name: OC_LDAP_SERVER_WRITE_ENABLED
               value: {{ .Values.opencloud.ldapServerWriteEnabled | quote }}
             - name: GRAPH_LDAP_SERVER_WRITE_ENABLED
@@ -541,10 +542,9 @@ spec:
                   name: {{ $initSecretName }}
                   key: serviceAccountID
             # Per-service LDAP bind passwords
-            {{- if has "idp" (.Values.opencloud.excludeServices | default (list)) }}
-            # External LDAP (built-in IDP excluded): bind against the external
-            # directory using the shared bind secret (opencloud.ldap.secretRef,
-            # or the chart-generated <release-name>-opencloud-ldap).
+            {{- $useExternalLdap := and (has "idp" (.Values.opencloud.excludeServices | default (list))) (not .Values.opencloud.ldap.keepIdm) }}
+            {{- if $useExternalLdap }}
+            # Bind against the external LDAP secret (opencloud.ldap.secretRef, or <release>-opencloud-ldap).
             - name: USERS_LDAP_BIND_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -571,9 +571,7 @@ spec:
                   name: {{ .Values.opencloud.ldap.secretRef | default (printf "%s-ldap" (include "opencloud.opencloud.fullname" .)) }}
                   key: graph-ldap-bind-password
             {{- else }}
-            # Built-in IDP (default): bind against the internal IDM LDAP using the
-            # generated service user passwords from the init secret — no external
-            # LDAP secret needed.
+            # Bind against the bundled IDM using passwords from the init secret.
             - name: USERS_LDAP_BIND_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/charts/opencloud/templates/opencloud/secrets.yaml
+++ b/charts/opencloud/templates/opencloud/secrets.yaml
@@ -30,7 +30,7 @@ stringData:
   secretKey: {{ .Values.opencloud.storage.s3.external.secretKey }}
 {{- end }}
 ---
-{{- /* External LDAP bind secret when idp is excluded and ldap.keepIdm is false. */}}
+{{- /* External LDAP bind secret when idp is excluded and opencloud.ldap.keepIdm is false. */}}
 {{- if and .Values.opencloud.enabled (has "idp" (.Values.opencloud.excludeServices | default (list))) (not .Values.opencloud.ldap.keepIdm) (not .Values.opencloud.ldap.secretRef) }}
 apiVersion: v1
 kind: Secret

--- a/charts/opencloud/templates/opencloud/secrets.yaml
+++ b/charts/opencloud/templates/opencloud/secrets.yaml
@@ -30,8 +30,8 @@ stringData:
   secretKey: {{ .Values.opencloud.storage.s3.external.secretKey }}
 {{- end }}
 ---
-{{- /* External LDAP bind secret — only needed when the built-in IDP is excluded (external OIDC/LDAP setup) */}}
-{{- if and .Values.opencloud.enabled (has "idp" (.Values.opencloud.excludeServices | default (list))) (not .Values.opencloud.ldap.secretRef) }}
+{{- /* External LDAP bind secret when idp is excluded and ldap.keepIdm is false. */}}
+{{- if and .Values.opencloud.enabled (has "idp" (.Values.opencloud.excludeServices | default (list))) (not .Values.opencloud.ldap.keepIdm) (not .Values.opencloud.ldap.secretRef) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/opencloud/tests/openldap_test.yaml
+++ b/charts/opencloud/tests/openldap_test.yaml
@@ -80,8 +80,8 @@ tests:
 
   # --- LDAP Bind Secret References ---
   # Bundled IDP: bind passwords from the init secret.
-  # idp excluded, ldap.keepIdm false: bind against *-opencloud-ldap; OC_LDAP_* from opencloud.ldap.
-  # idp excluded, ldap.keepIdm true: bind against the init secret; no OC_LDAP_URI.
+  # idp excluded, opencloud.ldap.keepIdm false: bind against *-opencloud-ldap; OC_LDAP_* from opencloud.ldap.
+  # idp excluded, opencloud.ldap.keepIdm true: bind against the init secret; no OC_LDAP_URI.
 
   - it: should not inject OC_LDAP_URI when only issuerUrl is set
     template: opencloud/deployment.yaml
@@ -171,7 +171,7 @@ tests:
             name: OC_EXCLUDE_RUN_SERVICES
             value: "idp"
 
-  - it: should keep bundled IDM when ldap.keepIdm is true and idp is excluded
+  - it: should keep bundled IDM when opencloud.ldap.keepIdm is true and idp is excluded
     template: opencloud/deployment.yaml
     set:
       oidc:
@@ -285,7 +285,7 @@ tests:
           path: stringData.graph-ldap-bind-password
           value: s3cret
 
-  - it: should not render the external LDAP bind secret when ldap.keepIdm is true
+  - it: should not render the external LDAP bind secret when opencloud.ldap.keepIdm is true
     template: opencloud/secrets.yaml
     set:
       opencloud:

--- a/charts/opencloud/tests/openldap_test.yaml
+++ b/charts/opencloud/tests/openldap_test.yaml
@@ -79,11 +79,25 @@ tests:
             value: "https://custom.example.com/account"
 
   # --- LDAP Bind Secret References ---
-  # With the built-in IDP (default), the per-service LDAP bind passwords come from
-  # the generated init secret (<release>-opencloud-opencloud-init) — no external
-  # LDAP secret is needed. When the built-in IDP is excluded (external OIDC/LDAP
-  # setup), they come from the external LDAP bind secret
-  # <release>-opencloud-opencloud-ldap (overridable via opencloud.ldap.secretRef).
+  # Bundled IDP: bind passwords from the init secret.
+  # idp excluded, ldap.keepIdm false: bind against *-opencloud-ldap; OC_LDAP_* from opencloud.ldap.
+  # idp excluded, ldap.keepIdm true: bind against the init secret; no OC_LDAP_URI.
+
+  - it: should not inject OC_LDAP_URI when only issuerUrl is set
+    template: opencloud/deployment.yaml
+    set:
+      oidc:
+        issuerUrl: https://auth.example.com/application/o/opencloud/
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OC_LDAP_URI
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OC_EXCLUDE_RUN_SERVICES
+            value: "idp"
 
   - it: should use the init secret for LDAP bind passwords with the built-in IDP (default)
     template: opencloud/deployment.yaml
@@ -137,6 +151,63 @@ tests:
                 name: RELEASE-NAME-opencloud-opencloud-ldap
                 key: graph-ldap-bind-password
 
+  - it: should inject OC_LDAP_URI when issuerUrl is set and idp is excluded
+    template: opencloud/deployment.yaml
+    set:
+      oidc:
+        issuerUrl: https://keycloak.opencloud.test/realms/openCloud
+      opencloud:
+        excludeServices:
+          - idp
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OC_LDAP_URI
+            value: "ldaps://openldap.openldap.svc.cluster.local:636"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OC_EXCLUDE_RUN_SERVICES
+            value: "idp"
+
+  - it: should keep bundled IDM when ldap.keepIdm is true and idp is excluded
+    template: opencloud/deployment.yaml
+    set:
+      oidc:
+        issuerUrl: https://auth.example.com/application/o/opencloud/
+      opencloud:
+        ldap:
+          keepIdm: true
+        excludeServices:
+          - idp
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OC_LDAP_URI
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OC_EXCLUDE_RUN_SERVICES
+            value: "idp"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: USERS_LDAP_BIND_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-opencloud-opencloud-init
+                key: idmRevaServicePassword
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GRAPH_LDAP_BIND_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-opencloud-opencloud-init
+                key: idmServicePassword
+
   # --- OC_URL scheme ---
   # The built-in IDP requires an https issuer URL, so OC_URL must be https
   # whenever the IDP runs (Gateway terminates TLS), even if global.tls.enabled
@@ -151,9 +222,26 @@ tests:
             name: OC_URL
             value: https://cloud.opencloud.test
 
+  - it: should keep https OC_URL when the bundled IDP is excluded and tls.external is true
+    template: opencloud/deployment.yaml
+    set:
+      opencloud:
+        excludeServices:
+          - idp
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OC_URL
+            value: https://cloud.opencloud.test
+
   - it: should use http OC_URL when the built-in IDP is excluded and TLS is disabled
     template: opencloud/deployment.yaml
     set:
+      global:
+        tls:
+          enabled: false
+          external: false
       opencloud:
         excludeServices:
           - idp
@@ -196,6 +284,20 @@ tests:
       - equal:
           path: stringData.graph-ldap-bind-password
           value: s3cret
+
+  - it: should not render the external LDAP bind secret when ldap.keepIdm is true
+    template: opencloud/secrets.yaml
+    set:
+      opencloud:
+        existingSecret: existing
+        excludeServices:
+          - idp
+        ldap:
+          keepIdm: true
+          adminPassword: s3cret
+    asserts:
+      - hasDocuments:
+          count: 0
 
   # --- S3 Credentials Secret References ---
 

--- a/charts/opencloud/values.schema.json
+++ b/charts/opencloud/values.schema.json
@@ -174,6 +174,9 @@
             "ldap": {
               "type": "object",
               "properties": {
+                "keepIdm": {
+                  "type": "boolean"
+                },
                 "writeable": {
                   "type": "boolean"
                 },

--- a/charts/opencloud/values.yaml
+++ b/charts/opencloud/values.yaml
@@ -72,14 +72,13 @@ busybox:
 # IDENTITY PROVIDER (OIDC)
 # =====================================================================
 
-# OIDC (OpenID Connect) settings for identity and access management
-# Leave oidc.issuerUrl empty to use the integrated IDM (built-in identity provider).
-# Set oidc.issuerUrl to an external OIDC provider (e.g., Keycloak, Auth0, Okta, Azure AD)
-# to use external authentication instead.
+# OIDC (OpenID Connect) settings for identity and access management.
+# Leave oidc.issuerUrl empty to use the bundled IDP.
+# Set it to an external OIDC provider (Authentik, Keycloak, Auth0, …) to replace login.
 oidc:
   # OIDC Issuer URL (optional)
-  # Leave empty to use the integrated IDM (no external OIDC provider required).
-  # Set to the base URL of your external OIDC provider when using external auth:
+  # Leave empty to use the bundled IDP. Set to the issuer of an external OIDC provider:
+  #   Authentik: https://auth.example.com/application/o/opencloud/
   #   Keycloak: https://keycloak.example.com/realms/openCloud
   #   Auth0: https://your-tenant.auth0.com
   #   Okta: https://your-org.okta.com/oauth2/default
@@ -347,17 +346,19 @@ opencloud:
   proxyOidcAccessTokenVerifyMethod: "jwt"
   # LDAP server write enabled (default: true)
   ldapServerWriteEnabled: true
-  # LDAP configuration (used when externalUserManagement is enabled)
+  # LDAP directory used when excludeServices contains "idp".
   ldap:
+    # Keep the bundled IDM as the user directory when idp is excluded.
+    # false: OC_LDAP_* points at opencloud.ldap.uri.
+    # true: accounts stay in the bundled IDM. Do not exclude idm.
+    keepIdm: false
     uri: "ldaps://openldap.openldap.svc.cluster.local:636"
     insecure: true
     bindDN: "cn=admin,dc=opencloud,dc=eu"
     adminPassword: "admin"  # Must match OpenLDAP adminPassword
-    # Name of the secret containing LDAP bind passwords (keys: reva-ldap-bind-password,
-    # graph-ldap-bind-password). Only used when the built-in IDP is excluded
-    # (opencloud.excludeServices contains "idp", i.e. external OIDC/LDAP setup).
-    # If not set, defaults to <release-name>-opencloud-ldap, which the chart
-    # generates from adminPassword in that case.
+    # Secret with reva-ldap-bind-password / graph-ldap-bind-password.
+    # Used when excludeServices contains "idp" and ldap.keepIdm is false.
+    # Defaults to <release-name>-opencloud-ldap generated from adminPassword.
     secretRef: ""
     user:
       baseDN: "ou=users,dc=opencloud,dc=eu"
@@ -420,8 +421,10 @@ opencloud:
   asyncUploads: true
   # Additional services to start
   additionalServices: []
-  # Services to exclude from starting
-  # Leave empty so the built-in IDP runs when using integrated IDM
+  # Services to exclude from starting.
+  # Leave empty so the bundled IDP and IDM both run.
+  # Add "idp" to use an external OIDC provider.
+  # Add "idm" when an external LDAP server replaces the bundled IDM.
   excludeServices: [] # necessary that idp runs
   env: []
   envFrom: []

--- a/charts/opencloud/values.yaml
+++ b/charts/opencloud/values.yaml
@@ -357,7 +357,7 @@ opencloud:
     bindDN: "cn=admin,dc=opencloud,dc=eu"
     adminPassword: "admin"  # Must match OpenLDAP adminPassword
     # Secret with reva-ldap-bind-password / graph-ldap-bind-password.
-    # Used when excludeServices contains "idp" and ldap.keepIdm is false.
+    # Used when excludeServices contains "idp" and opencloud.ldap.keepIdm is false.
     # Defaults to <release-name>-opencloud-ldap generated from adminPassword.
     secretRef: ""
     user:


### PR DESCRIPTION
OpenCloud splits login and the user directory:

- **IDP** is login (bundled OIDC, or Authentik / Keycloak / Authelia)
- **IDM** is the user database (bundled LibreIDM, or a real OpenLDAP)

The chart currently treats those as one switch. Setting `excludeServices: [idp]` to use Authentik also rewires every LDAP setting to `ldaps://openldap.openldap.svc.cluster.local`. If you did not deploy OpenLDAP, the users service fails DNS, `/graph/v1.0/me` returns 500, and accounts never get created.

That coupling is only right for one of the two official layouts:

1. External OIDC + OpenLDAP (`idm/external-idp.yml`): exclude `idm` and `idp`, run OpenLDAP.
2. External OIDC + bundled IDM (Authelia / the official external-IDP docs): exclude `idp` only. Users autoprovision into IDM. No LDAP server.

I first tried to make layout 2 the default. That would silently break existing OpenLDAP installs: `OC_LDAP_*` would disappear unless they set a new flag. So this PR does not change 3.0.0 behaviour.

`opencloud.ldap.keepIdm` defaults to `false`. Excluding `idp` still points LDAP at OpenLDAP, same as today.

Set it to `true` when you want layout 2:

```yaml
oidc:
  issuerUrl: https://auth.example.com/application/o/opencloud/
opencloud:
  ldap:
    keepIdm: true
  excludeServices:
    - idp
```

Do not exclude `idm` on that path.

---

I used AI to understand the inner workings of this chart, and for suggestions and help implementing the required changes.