### PR TITLE
fix(identity): add opencloud.ldap.keepIdm for external OIDC without OpenLDAP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 <!-- release-bot:start -->
 
+## [Unreleased]
+
+### Fixes
+- Add `opencloud.ldap.keepIdm` so external OIDC can keep the bundled IDM (LibreIDM) instead of OpenLDAP. Default is unchanged: `excludeServices: [idp]` still points `OC_LDAP_*` at `openldap.openldap.svc`.
+
+### Upgrade notes
+- None. Existing OpenLDAP installs that exclude `idp` keep working with no new values. The supported external-LDAP layout excludes both `idp` and `idm`.
+- Authentik / Authelia (external OIDC, no OpenLDAP): set `oidc.issuerUrl`, `excludeServices: [idp]`, and `opencloud.ldap.keepIdm: true`. Do **not** exclude `idm`.
+
 ## [3.0.0] - 2026-08-30
 
 ### Breaking Changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,35 @@ git checkout -b feature/your-feature-name
 When making changes, please ensure you:
 - Follow Helm best practices
 - Include proper documentation
-- Test your changes with `helm lint` and installation tests
+- Run the required chart validation commands below
+
+#### Required Helm validation
+
+From the repository root, run both commands before opening or updating a PR:
+
+```bash
+helm lint charts/opencloud --strict
+helm unittest charts/opencloud
+```
+
+`helm-unittest` is a Helm plugin. Install it once if it is not available:
+
+```bash
+# The plugin repository does not publish Helm provenance metadata.
+helm plugin install --verify=false https://github.com/helm-unittest/helm-unittest.git
+```
+
+Also render the chart for a basic syntax check:
+
+```bash
+helm template test charts/opencloud >/dev/null
+```
+
+For changes affecting a deployed release, run the Helm integration tests as well:
+
+```bash
+helm test <release-name> --namespace <namespace>
+```
 
 ### 4. Submit a Pull Request
 

--- a/charts/opencloud/README.md
+++ b/charts/opencloud/README.md
@@ -289,7 +289,9 @@ This will prepend `my-registry.com/` to all image references in the chart. For e
 | `opencloud.adminPassword` | Admin password | `admin` |
 | `opencloud.createDemoUsers` | Create demo users (default `true` for integrated IDM) | `true` |
 | `opencloud.asyncUploads` | Keep upload sessions available during postprocessing | `true` |
-| `opencloud.excludeServices` | Services to exclude from starting (set `["idp"]` when using external OIDC). The external LDAP env vars (`OC_LDAP_*`, `GRAPH_LDAP_*`, `FRONTEND_LDAP_SERVER_WRITE_ENABLED`) and the external LDAP bind secret (`opencloud.ldap.secretRef`, default `<release-name>-opencloud-ldap`, chart-generated from `opencloud.ldap.adminPassword`) are only used when `idp` is excluded; with the built-in IDP running they are omitted and the bind passwords come from the generated init secret. | `[]` |
+| `opencloud.excludeServices` | Services to exclude from starting. Set `["idp"]` for external OIDC with bundled IDM. For external OIDC with external LDAP, set `["idp", "idm"]`. | `[]` |
+| `opencloud.ldap.keepIdm` | Keep the bundled IDM as the user directory when `idp` is excluded. `false`: `OC_LDAP_*` points at `opencloud.ldap.uri`. `true`: accounts stay in IDM. | `false` |
+| `opencloud.ldap.secretRef` | Existing Secret with `reva-ldap-bind-password` / `graph-ldap-bind-password` (used when `idp` is excluded and `ldap.keepIdm` is false) | `""` |
 | `opencloud.theme.urls.imprint` | Imprint URL shown in the web UI footer (empty = hidden) | `https://opencloud.eu/en/legal-notice` |
 | `opencloud.theme.urls.privacy` | Privacy policy URL shown in the web UI footer (empty = hidden) | `https://opencloud.eu/en/data-protection-notice` |
 | `opencloud.theme.urls.accessibility` | Accessibility statement URL shown in the web UI footer (empty = hidden) | `https://opencloud.eu/en/accessibility-statement` |
@@ -463,13 +465,22 @@ opencloud:
 
 
 
-The chart uses the **integrated IDM** by default. To use an external OIDC provider, set `oidc.issuerUrl` and exclude the `idp` service.
+The chart uses the **bundled IDP** (LibreGraph Connect) and **bundled IDM** (LibreIDM LDAP) by default. Those are two different services:
+
+| Piece | What it is | Bundled process | External replacement |
+| ----- | ---------- | --------------- | -------------------- |
+| **IDP** | Login (OIDC) | `idp` | Authentik, Keycloak, Authelia, Auth0, … (`oidc.issuerUrl` + `excludeServices: [idp]`) |
+| **IDM** | User directory (LDAP) | `idm` | OpenLDAP / AD (`OC_LDAP_*` + `excludeServices: [idp, idm]`) |
+
+When `excludeServices` contains `idp` and `ldap.keepIdm` is `false`, the chart sets `OC_LDAP_*` from `opencloud.ldap` (default `ldaps://openldap.openldap.svc.cluster.local:636`). For the supported external-LDAP layout, also exclude `idm`. Set `opencloud.ldap.keepIdm: true` to keep accounts in the bundled IDM instead.
+
+`keepIdm` selects the directory; it does not migrate users. Do not toggle it on an existing installation without migrating the user directory and checking user IDs, ownership, and shares.
 
 ### OIDC Settings
 
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
-| `oidc.issuerUrl` | OIDC Issuer URL (leave empty for integrated IDM) | `""` |
+| `oidc.issuerUrl` | OIDC Issuer URL (leave empty for the bundled IDP) | `""` |
 | `oidc.clientId` | OIDC Client ID | `"web"` |
 | `oidc.accountUrl` | Account management URL (optional; derived from `issuerUrl` if empty) | `""` |
 | `oidc.oidcIdpInsecure` | Disable TLS certificate validation for OIDC provider | `false` |
@@ -483,7 +494,33 @@ The chart uses the **integrated IDM** by default. To use an external OIDC provid
 | `oidc.cors.allowCredentials` | Allow credentials | `"true"` |
 | `oidc.cors.maxAge` | Max age in seconds | `"3600"` |
 
-#### Example: Using External OIDC Provider
+#### Example: External OIDC + bundled IDM
+
+Login goes to the external OIDC provider. Users autoprovision into IDM.
+
+```yaml
+oidc:
+  issuerUrl: "https://auth.example.com/application/o/opencloud/"
+  clientId: "web"
+  accountUrl: "https://auth.example.com/if/user/#/settings"
+  scope: "openid profile email groups"
+
+opencloud:
+  createDemoUsers: false
+  ldap:
+    keepIdm: true
+  excludeServices:
+    - idp
+  proxyOidcAccessTokenVerifyMethod: "none"
+  proxyRoleAssignmentOidcClaim: "groups"
+  proxyAutoprovisionClaimUsername: "preferred_username"
+  oidc:
+    scope: "openid profile email groups"
+```
+
+#### Example: External OIDC + OpenLDAP
+
+Excluding `idp` with `ldap.keepIdm: false` points LDAP at `opencloud.ldap.uri`. Deploy OpenLDAP yourself (the chart does not ship it).
 
 ```yaml
 oidc:
@@ -494,7 +531,12 @@ oidc:
 opencloud:
   createDemoUsers: false
   excludeServices:
-    - "idp"
+    - idp
+    - idm
+  ldap:
+    uri: "ldaps://openldap.openldap.svc.cluster.local:636"
+    bindDN: "cn=admin,dc=opencloud,dc=eu"
+    adminPassword: "changeme"
 ```
 
 ### Collabora Settings

--- a/charts/opencloud/deployments/flux/opencloud/opencloud.yaml
+++ b/charts/opencloud/deployments/flux/opencloud/opencloud.yaml
@@ -134,11 +134,12 @@ spec:
         enabled: false
       # Keep TUS uploads available until policy and antivirus postprocessing completes.
       asyncUploads: true
-      # Using external Keycloak OIDC + external OpenLDAP: the bundled IDM/idp
-      # service must NOT run, so exclude it. Demo users are also disabled.
+      # Using external Keycloak OIDC + external OpenLDAP: the bundled idm/idp
+      # services must NOT run, so exclude them. Demo users are also disabled.
       createDemoUsers: false
       excludeServices:
         - "idp"
+        - "idm"
       persistence:
         data:
           accessMode: ReadWriteMany  
@@ -373,11 +374,12 @@ spec:
 #       logLevel: info
 #       migration:
 #         enabled: false
-#       # Using external Keycloak OIDC + external OpenLDAP: the bundled IDM/idp
-#       # service must NOT run, so exclude it. Demo users are also disabled.
+#       # Using external Keycloak OIDC + external OpenLDAP: the bundled idm/idp
+#       # services must NOT run, so exclude them. Demo users are also disabled.
 #       createDemoUsers: false
 #       excludeServices:
 #         - "idp"
+#         - "idm"
 #       persistence:
 #         data:
 #           accessMode: ReadWriteOnce  # RWO: only one pod can mount at a time; the chart auto-switches the Deployment strategy to Recreate

--- a/charts/opencloud/templates/opencloud/deployment.yaml
+++ b/charts/opencloud/templates/opencloud/deployment.yaml
@@ -1,4 +1,11 @@
 {{- if .Values.opencloud.enabled }}
+{{- /* LDAP directory selection: external OpenLDAP vs bundled IDM (LibreIDM). */}}
+{{- $excludeServices := .Values.opencloud.excludeServices | default (list) }}
+{{- $keepIdm := .Values.opencloud.ldap.keepIdm | default false }}
+{{- $useExternalLdap := and (has "idp" $excludeServices) (not $keepIdm) }}
+{{- if and $keepIdm (has "idm" $excludeServices) }}
+{{- fail "opencloud.ldap.keepIdm=true requires the bundled IDM to run: remove \"idm\" from opencloud.excludeServices" }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -410,8 +417,8 @@ spec:
               value: {{ printf "%s/.well-known/openid-configuration" (include "opencloud.oidc.issuer" .) | quote }}
             - name: WEB_OIDC_SCOPE
               value: {{ .Values.opencloud.oidc.scope | quote }}
-            {{- /* External LDAP settings are only needed when the built-in IDP is excluded (external OIDC/LDAP setup) */}}
-            {{- if has "idp" (.Values.opencloud.excludeServices | default (list)) }}
+            {{- /* OC_LDAP_* against opencloud.ldap.uri when idp is excluded and opencloud.ldap.keepIdm is false. */}}
+            {{- if $useExternalLdap }}
             - name: OC_LDAP_SERVER_WRITE_ENABLED
               value: {{ .Values.opencloud.ldapServerWriteEnabled | quote }}
             - name: GRAPH_LDAP_SERVER_WRITE_ENABLED
@@ -541,10 +548,8 @@ spec:
                   name: {{ $initSecretName }}
                   key: serviceAccountID
             # Per-service LDAP bind passwords
-            {{- if has "idp" (.Values.opencloud.excludeServices | default (list)) }}
-            # External LDAP (built-in IDP excluded): bind against the external
-            # directory using the shared bind secret (opencloud.ldap.secretRef,
-            # or the chart-generated <release-name>-opencloud-ldap).
+            {{- if $useExternalLdap }}
+            # Bind against the external LDAP secret (opencloud.ldap.secretRef, or <release>-opencloud-ldap).
             - name: USERS_LDAP_BIND_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -571,9 +576,7 @@ spec:
                   name: {{ .Values.opencloud.ldap.secretRef | default (printf "%s-ldap" (include "opencloud.opencloud.fullname" .)) }}
                   key: graph-ldap-bind-password
             {{- else }}
-            # Built-in IDP (default): bind against the internal IDM LDAP using the
-            # generated service user passwords from the init secret — no external
-            # LDAP secret needed.
+            # Bind against the bundled IDM using passwords from the init secret.
             - name: USERS_LDAP_BIND_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/charts/opencloud/templates/opencloud/secrets.yaml
+++ b/charts/opencloud/templates/opencloud/secrets.yaml
@@ -30,8 +30,8 @@ stringData:
   secretKey: {{ .Values.opencloud.storage.s3.external.secretKey }}
 {{- end }}
 ---
-{{- /* External LDAP bind secret — only needed when the built-in IDP is excluded (external OIDC/LDAP setup) */}}
-{{- if and .Values.opencloud.enabled (has "idp" (.Values.opencloud.excludeServices | default (list))) (not .Values.opencloud.ldap.secretRef) }}
+{{- /* External LDAP bind secret when idp is excluded and opencloud.ldap.keepIdm is false. */}}
+{{- if and .Values.opencloud.enabled (has "idp" (.Values.opencloud.excludeServices | default (list))) (not (.Values.opencloud.ldap.keepIdm | default false)) (not .Values.opencloud.ldap.secretRef) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/opencloud/tests/openldap_test.yaml
+++ b/charts/opencloud/tests/openldap_test.yaml
@@ -79,11 +79,25 @@ tests:
             value: "https://custom.example.com/account"
 
   # --- LDAP Bind Secret References ---
-  # With the built-in IDP (default), the per-service LDAP bind passwords come from
-  # the generated init secret (<release>-opencloud-opencloud-init) — no external
-  # LDAP secret is needed. When the built-in IDP is excluded (external OIDC/LDAP
-  # setup), they come from the external LDAP bind secret
-  # <release>-opencloud-opencloud-ldap (overridable via opencloud.ldap.secretRef).
+  # Bundled IDP: bind passwords from the init secret.
+  # idp excluded, opencloud.ldap.keepIdm false: bind against *-opencloud-ldap; OC_LDAP_* from opencloud.ldap.
+  # idp excluded, opencloud.ldap.keepIdm true: bind against the init secret; no OC_LDAP_URI.
+
+  - it: should not inject OC_LDAP_URI when only issuerUrl is set
+    template: opencloud/deployment.yaml
+    set:
+      oidc:
+        issuerUrl: https://auth.example.com/application/o/opencloud/
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OC_LDAP_URI
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OC_EXCLUDE_RUN_SERVICES
+            value: "idp"
 
   - it: should use the init secret for LDAP bind passwords with the built-in IDP (default)
     template: opencloud/deployment.yaml
@@ -137,6 +151,117 @@ tests:
                 name: RELEASE-NAME-opencloud-opencloud-ldap
                 key: graph-ldap-bind-password
 
+  - it: should inject OC_LDAP_URI when issuerUrl is set and idp is excluded
+    template: opencloud/deployment.yaml
+    set:
+      oidc:
+        issuerUrl: https://keycloak.opencloud.test/realms/openCloud
+      opencloud:
+        excludeServices:
+          - idp
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OC_LDAP_URI
+            value: "ldaps://openldap.openldap.svc.cluster.local:636"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OC_EXCLUDE_RUN_SERVICES
+            value: "idp"
+
+  - it: should keep the external LDAP configuration and custom bind secret when idp and idm are excluded
+    template: opencloud/deployment.yaml
+    set:
+      oidc:
+        issuerUrl: https://keycloak.opencloud.test/realms/openCloud
+      opencloud:
+        excludeServices:
+          - idp
+          - idm
+        ldap:
+          secretRef: ldap-bind-secrets
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OC_EXCLUDE_RUN_SERVICES
+            value: "idp,idm"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OC_LDAP_URI
+            value: "ldaps://openldap.openldap.svc.cluster.local:636"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: USERS_LDAP_BIND_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: ldap-bind-secrets
+                key: reva-ldap-bind-password
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GRAPH_LDAP_BIND_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: ldap-bind-secrets
+                key: graph-ldap-bind-password
+
+  - it: should keep bundled IDM when opencloud.ldap.keepIdm is true and idp is excluded
+    template: opencloud/deployment.yaml
+    set:
+      oidc:
+        issuerUrl: https://auth.example.com/application/o/opencloud/
+      opencloud:
+        ldap:
+          keepIdm: true
+        excludeServices:
+          - idp
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OC_LDAP_URI
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OC_EXCLUDE_RUN_SERVICES
+            value: "idp"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: USERS_LDAP_BIND_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-opencloud-opencloud-init
+                key: idmRevaServicePassword
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GRAPH_LDAP_BIND_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-opencloud-opencloud-init
+                key: idmServicePassword
+
+  - it: should reject keepIdm when the bundled IDM is excluded
+    template: opencloud/deployment.yaml
+    set:
+      oidc:
+        issuerUrl: https://auth.example.com/application/o/opencloud/
+      opencloud:
+        ldap:
+          keepIdm: true
+        excludeServices:
+          - idp
+          - idm
+    asserts:
+      - failedTemplate:
+          errorPattern: 'opencloud\.ldap\.keepIdm=true requires the bundled IDM to run'
+
   # --- OC_URL scheme ---
   # The built-in IDP requires an https issuer URL, so OC_URL must be https
   # whenever the IDP runs (Gateway terminates TLS), even if global.tls.enabled
@@ -154,6 +279,10 @@ tests:
   - it: should use http OC_URL when the built-in IDP is excluded and TLS is disabled
     template: opencloud/deployment.yaml
     set:
+      global:
+        tls:
+          enabled: false
+          external: false
       opencloud:
         excludeServices:
           - idp
@@ -196,6 +325,20 @@ tests:
       - equal:
           path: stringData.graph-ldap-bind-password
           value: s3cret
+
+  - it: should not render the external LDAP bind secret when opencloud.ldap.keepIdm is true
+    template: opencloud/secrets.yaml
+    set:
+      opencloud:
+        existingSecret: existing
+        excludeServices:
+          - idp
+        ldap:
+          keepIdm: true
+          adminPassword: s3cret
+    asserts:
+      - hasDocuments:
+          count: 0
 
   # --- S3 Credentials Secret References ---
 

--- a/charts/opencloud/values.schema.json
+++ b/charts/opencloud/values.schema.json
@@ -334,6 +334,14 @@
         "asyncUploads": {
           "type": "boolean"
         },
+        "ldap": {
+          "type": "object",
+          "properties": {
+            "keepIdm": {
+              "type": "boolean"
+            }
+          }
+        },
         "antivirus": {
           "type": "object",
           "properties": {

--- a/charts/opencloud/values.yaml
+++ b/charts/opencloud/values.yaml
@@ -347,17 +347,19 @@ opencloud:
   proxyOidcAccessTokenVerifyMethod: "jwt"
   # LDAP server write enabled (default: true)
   ldapServerWriteEnabled: true
-  # LDAP configuration (used when externalUserManagement is enabled)
+  # LDAP directory used when excludeServices contains "idp".
   ldap:
+    # Keep the bundled IDM as the user directory when idp is excluded.
+    # false: OC_LDAP_* points at opencloud.ldap.uri (external OpenLDAP).
+    # true: accounts stay in the bundled IDM. Do not exclude idm.
+    keepIdm: false
     uri: "ldaps://openldap.openldap.svc.cluster.local:636"
     insecure: true
     bindDN: "cn=admin,dc=opencloud,dc=eu"
     adminPassword: "admin"  # Must match OpenLDAP adminPassword
-    # Name of the secret containing LDAP bind passwords (keys: reva-ldap-bind-password,
-    # graph-ldap-bind-password). Only used when the built-in IDP is excluded
-    # (opencloud.excludeServices contains "idp", i.e. external OIDC/LDAP setup).
-    # If not set, defaults to <release-name>-opencloud-ldap, which the chart
-    # generates from adminPassword in that case.
+    # Secret with reva-ldap-bind-password / graph-ldap-bind-password.
+    # Used when excludeServices contains "idp" and opencloud.ldap.keepIdm is false.
+    # Defaults to <release-name>-opencloud-ldap generated from adminPassword.
     secretRef: ""
     user:
       baseDN: "ou=users,dc=opencloud,dc=eu"
@@ -420,8 +422,10 @@ opencloud:
   asyncUploads: true
   # Additional services to start
   additionalServices: []
-  # Services to exclude from starting
-  # Leave empty so the built-in IDP runs when using integrated IDM
+  # Services to exclude from starting.
+  # Leave empty so the bundled IDP and IDM both run.
+  # Add "idp" to use an external OIDC provider.
+  # Add "idm" when an external LDAP server replaces the bundled IDM.
   excludeServices: [] # necessary that idp runs
   env: []
   envFrom: []


### PR DESCRIPTION
Builds on and supersedes #167 (thanks @HttpRafa for the original work).

I checked PR #167 on a real cluster (external Keycloak, Flux) and it works. This takes the same approach with some smaller changes and fixes:

- `opencloud.ldap.keepIdm` (default `false`): `excludeServices: [idp]` keeps pointing `OC_LDAP_*` at OpenLDAP — existing installs unaffected. Set `keepIdm: true` (and do **not** exclude `idm`) to keep accounts in the bundled IDM with external OIDC.
- Schema fix: `keepIdm` is validated under `opencloud.ldap` (PR #167 placed it under `features.externalUserManagement.ldap`, where it validated nothing and the real value went unchecked).
- Guard: `keepIdm: true` + excluded `idm` now fails fast with a clear message instead of rendering a deployment with no user directory.
- Flux example (`deployments/flux/opencloud/opencloud.yaml`) now excludes `idp` + `idm` for the supported external-LDAP layout.
- Tests: added keepIdm cases (external LDAP with custom `secretRef`, bundled IDM binds from init secret, invalid-combo failure); fixed the pre-existing http `OC_URL` test which never disabled `global.tls.external`.
- Docs: IDP vs IDM split, both examples, and a note that `keepIdm` selects the directory (no user migration).
- `CONTRIBUTING.md`: documented required `helm lint --strict` + `helm unittest` validation.

Verified: `helm lint --strict`, `helm template` for all LDAP combinations, `openldap_test.yaml` 20/20 pass, Flux reconcile of the branch on a live cluster.